### PR TITLE
rmplan utility

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,7 @@
         "ai": "^4.3.9",
         "change-case": "^5.4.4",
         "clipboardy": "^4.0.0",
+        "commander": "^13.1.0",
         "diff": "^7.0.0",
         "find-up": "^7.0.0",
         "glob": "^11.0.1",
@@ -177,6 +178,8 @@
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@ai-sdk/groq": "^1.2.8",
         "@ai-sdk/openai": "^1.3.16",
         "@ai-sdk/xai": "^1.2.14",
+        "@inquirer/prompts": "^7.5.0",
         "@openrouter/ai-sdk-provider": "^0.4.5",
         "@types/glob": "^8.1.0",
         "@xmldom/xmldom": "^0.9.8",
@@ -97,6 +98,34 @@
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.2", "", {}, "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ=="],
 
+    "@inquirer/checkbox": ["@inquirer/checkbox@4.1.5", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/figures": "^1.0.11", "@inquirer/type": "^3.0.6", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@5.1.9", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w=="],
+
+    "@inquirer/core": ["@inquirer/core@10.1.10", "", { "dependencies": { "@inquirer/figures": "^1.0.11", "@inquirer/type": "^3.0.6", "ansi-escapes": "^4.3.2", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw=="],
+
+    "@inquirer/editor": ["@inquirer/editor@4.2.10", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6", "external-editor": "^3.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw=="],
+
+    "@inquirer/expand": ["@inquirer/expand@4.0.12", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw=="],
+
+    "@inquirer/figures": ["@inquirer/figures@1.0.11", "", {}, "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw=="],
+
+    "@inquirer/input": ["@inquirer/input@4.1.9", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA=="],
+
+    "@inquirer/number": ["@inquirer/number@3.0.12", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q=="],
+
+    "@inquirer/password": ["@inquirer/password@4.0.12", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6", "ansi-escapes": "^4.3.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@7.5.0", "", { "dependencies": { "@inquirer/checkbox": "^4.1.5", "@inquirer/confirm": "^5.1.9", "@inquirer/editor": "^4.2.10", "@inquirer/expand": "^4.0.12", "@inquirer/input": "^4.1.9", "@inquirer/number": "^3.0.12", "@inquirer/password": "^4.0.12", "@inquirer/rawlist": "^4.1.0", "@inquirer/search": "^3.0.12", "@inquirer/select": "^4.2.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-tk8Bx7l5AX/CR0sVfGj3Xg6v7cYlFBkEahH+EgBB+cZib6Fc83dwerTbzj7f2+qKckjIUGsviWRI1d7lx6nqQA=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@4.1.0", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-6ob45Oh9pXmfprKqUiEeMz/tjtVTFQTgDDz1xAMKMrIvyrYjAmRbQZjMJfsictlL4phgjLhdLu27IkHNnNjB7g=="],
+
+    "@inquirer/search": ["@inquirer/search@3.0.12", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/figures": "^1.0.11", "@inquirer/type": "^3.0.6", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ=="],
+
+    "@inquirer/select": ["@inquirer/select@4.2.0", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/figures": "^1.0.11", "@inquirer/type": "^3.0.6", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-KkXQ4aSySWimpV4V/TUJWdB3tdfENZUU765GjOIZ0uPwdbGIG6jrxD4dDf1w68uP+DVtfNhr1A92B+0mbTZ8FA=="],
+
+    "@inquirer/type": ["@inquirer/type@3.0.6", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA=="],
+
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
@@ -153,6 +182,8 @@
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
+    "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
+
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -172,6 +203,10 @@
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
+
+    "chardet": ["chardet@0.7.0", "", {}, "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
 
     "clipboardy": ["clipboardy@4.0.0", "", { "dependencies": { "execa": "^8.0.1", "is-wsl": "^3.1.0", "is64bit": "^2.0.0" } }, "sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w=="],
 
@@ -221,6 +256,8 @@
 
     "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
+    "external-editor": ["external-editor@3.1.0", "", { "dependencies": { "chardet": "^0.7.0", "iconv-lite": "^0.4.24", "tmp": "^0.0.33" } }, "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
@@ -262,6 +299,8 @@
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
     "human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
+
+    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -327,6 +366,8 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
     "nan": ["nan@2.22.2", "", {}, "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -342,6 +383,8 @@
     "onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
 
     "p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
 
@@ -381,6 +424,8 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
 
     "semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
@@ -415,6 +460,8 @@
 
     "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
 
+    "tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "~1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "tree-sitter": ["tree-sitter@0.22.4", "", { "dependencies": { "node-addon-api": "^8.3.0", "node-gyp-build": "^4.8.4" } }, "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg=="],
@@ -432,6 +479,8 @@
     "ts-api-utils": ["ts-api-utils@2.0.1", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
 
@@ -451,13 +500,15 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
 
     "yocto-queue": ["yocto-queue@1.2.1", "", {}, "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg=="],
+
+    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.2", "", {}, "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA=="],
 
     "zod": ["zod@3.24.3", "", {}, "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg=="],
 
@@ -468,6 +519,8 @@
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@openrouter/ai-sdk-provider/@ai-sdk/provider": ["@ai-sdk/provider@1.0.9", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA=="],
 
@@ -495,11 +548,15 @@
 
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+    "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
@@ -514,6 +571,10 @@
     "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "eslint/find-up/locate-path/p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@ai-sdk/groq": "^1.2.8",
     "@ai-sdk/openai": "^1.3.16",
     "@ai-sdk/xai": "^1.2.14",
+    "@inquirer/prompts": "^7.5.0",
     "@openrouter/ai-sdk-provider": "^0.4.5",
     "@types/glob": "^8.1.0",
     "@xmldom/xmldom": "^0.9.8",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ai": "^4.3.9",
     "change-case": "^5.4.4",
     "clipboardy": "^4.0.0",
+    "commander": "^13.1.0",
     "diff": "^7.0.0",
     "find-up": "^7.0.0",
     "glob": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,17 @@
   "bin": {
     "apply-llm-edits": "./src/apply-llm-edits/cmd.ts",
     "rmfilter": "./src/rmfilter/rmfilter.ts",
-    "rmrun": "./src/rmrun.ts",
-    "rmfind": "./src/rmfind/rmfind.ts"
+    "rmfind": "./src/rmfind/rmfind.ts",
+    "rmplan": "./src/rmplan/rmplan.ts",
+    "rmrun": "./src/rmrun.ts"
   },
   "scripts": {
     "check": "tsc --noEmit",
-    "dev-install": "pnpm add -g file://$(pwd)"
+    "dev-install": "pnpm add -g file://$(pwd)",
+    "rmfilter": "src/rmfilter.ts",
+    "rmfind": "src/rmfind.ts",
+    "rmplan": "src/rmplan.ts",
+    "rmrun": "src/rmrun.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",

--- a/src/apply-llm-edits/apply.ts
+++ b/src/apply-llm-edits/apply.ts
@@ -8,13 +8,16 @@ export interface ApplyLlmEditsOptions {
   content: string;
   writeRoot?: string;
   dryRun?: boolean;
+  mode?: 'diff' | 'udiff' | 'xml' | 'whole';
 }
 
-export async function applyLlmEdits({ content, writeRoot, dryRun }: ApplyLlmEditsOptions) {
+export async function applyLlmEdits({ content, writeRoot, dryRun, mode }: ApplyLlmEditsOptions) {
   writeRoot ??= await getWriteRoot();
-  const xmlMode = content.includes('<code_changes>');
-  const diffMode = content.includes('<<<<<<< SEARCH');
-  const udiffMode = content.includes('```diff') && content.includes('@@');
+  const xmlMode = mode === 'xml' || content.includes('<code_changes>');
+  const diffMode = mode === 'diff' || content.includes('<<<<<<< SEARCH');
+  const udiffMode =
+    mode === 'udiff' ||
+    ((content.startsWith('--- ') || content.includes('```diff')) && content.includes('@@'));
 
   if (udiffMode) {
     return await processUnifiedDiff({

--- a/src/apply-llm-edits/cmd.ts
+++ b/src/apply-llm-edits/cmd.ts
@@ -17,6 +17,7 @@ if (args.includes('--help')) {
   console.log('Options:');
   console.log('  --stdin           Read input from stdin');
   console.log('  --cwd <path>      Write files based on the given path');
+  console.log('  --udiff           Force udiff mode');
   console.log('  --debug           Enable debug logging');
   console.log('  --dry-run         Dry run - do not apply changes');
   process.exit(0);
@@ -35,6 +36,7 @@ applyLlmEdits({
   content,
   writeRoot: await getWriteRoot(cwd),
   dryRun,
+  mode: args.includes('--udiff') ? 'udiff' : undefined,
 }).catch((err) => {
   console.error('Error processing input:', err);
   process.exit(1);

--- a/src/editor/udiff-simple/parse.test.ts
+++ b/src/editor/udiff-simple/parse.test.ts
@@ -64,6 +64,22 @@ Some text...
   expect(edit.hunk).toEqual(['-Original\n', '+Modified\n']);
 });
 
+test('find_diffs without fenced block', () => {
+  const content = `
+--- a/dir name with spaces/file.txt
++++ b/dir name with spaces/file.txt
+@@ ... @@
+-Original
++Modified`;
+  const edits = findDiffs(content);
+  console.log(edits);
+  expect(edits.length).toBe(1);
+
+  const edit = edits[0];
+  expect(edit.filePath).toBe('dir name with spaces/file.txt');
+  expect(edit.hunk).toEqual(['-Original\n', '+Modified\n']);
+});
+
 test('find multi diffs', () => {
   const content = `
 To implement the \`--check-update\` option, I will make the following changes:

--- a/src/rmfilter/additional_docs.ts
+++ b/src/rmfilter/additional_docs.ts
@@ -3,6 +3,7 @@ import { glob } from 'fast-glob';
 import os from 'node:os';
 import path from 'node:path';
 import { debugLog } from '../logging.ts';
+import { getUsingJj } from './utils.ts';
 
 export async function getAdditionalDocs(
   baseDir: string,
@@ -176,10 +177,6 @@ export async function getDiffTag(
     return { diffTag: '', changedFiles: [] };
   }
 
-  const usingJj = await Bun.file(path.join(baseDir, '.jj'))
-    .stat()
-    .then((s) => s.isDirectory())
-    .catch(() => false);
   const excludeFiles = [
     'pnpm-lock.yaml',
     'bun.lockb',
@@ -191,7 +188,7 @@ export async function getDiffTag(
 
   let diff = '';
   let changedFiles: string[] = [];
-  if (usingJj) {
+  if (await getUsingJj()) {
     const exclude = [...excludeFiles.map((f) => `~file:${f}`), '~glob:**/*_snapshot.json'].join(
       '&'
     );

--- a/src/rmfilter/instructions.ts
+++ b/src/rmfilter/instructions.ts
@@ -1,9 +1,9 @@
 import path from 'node:path';
 import { getGitRoot, logSpawn } from './utils.ts';
 
-export async function getInstructionsFromEditor() {
+export async function getInstructionsFromEditor(filename = 'repomix-instructions.md') {
   const gitRoot = await getGitRoot();
-  const instructionsFile = path.join(gitRoot, 'repomix-instructions.md');
+  const instructionsFile = path.join(gitRoot, filename);
   const editor = process.env.EDITOR || 'nano';
   let editorProcess = logSpawn([editor, instructionsFile], {
     stdio: ['inherit', 'inherit', 'inherit'],

--- a/src/rmfilter/rmfilter.ts
+++ b/src/rmfilter/rmfilter.ts
@@ -357,9 +357,13 @@ await Promise.all(
 // Add package.json for the relevant files to help inform the model about imports
 await Promise.all(
   Array.from(allFileDirs, async (d) => {
-    let pkg = await resolver.resolvePackageJson(d);
-    if (pkg?.path) {
-      allFilesSet.add(path.join(pkg.path, 'package.json'));
+    try {
+      let pkg = await resolver.resolvePackageJson(d);
+      if (pkg?.path) {
+        allFilesSet.add(path.join(pkg.path, 'package.json'));
+      }
+    } catch {
+      // it's fine if there is no package.json since we're not always in JS
     }
   })
 );

--- a/src/rmplan/cleanup.ts
+++ b/src/rmplan/cleanup.ts
@@ -36,7 +36,7 @@ Now, format the input text into valid YAML according to the following guidelines
 ${exampleFormat}
    \`\`\`
 
-2. Use quotes for strings containing special characters or when necessary to avoid YAML parsing errors.
+2. Use quotes for strings containing special characters or when necessary to avoid YAML parsing errors. Particularly, strings containing colons (:) should be quoted.
 
 3. For multi-line strings, use the pipe character (|) followed by the indented text on subsequent lines.
 
@@ -53,9 +53,20 @@ Output only the cleaned and formatted YAML, without any additional explanations 
 
 export async function cleanupYaml(input: string) {
   const prompt = cleanupPrompt(input);
-  const result = await generateText({
-    model: createModel('gemini-2.5-flash-preview-04-17'),
+  let { text } = await generateText({
+    model: createModel('google/gemini-2.5-flash-preview-04-17'),
     prompt,
   });
-  return result.text;
+
+  const startIndex = text.indexOf('goal:');
+  if (startIndex >= 0) {
+    text = text.slice(startIndex);
+  }
+
+  text = text.trimEnd();
+  if (text.endsWith('```')) {
+    text = text.slice(0, -3).trimEnd();
+  }
+
+  return text;
 }

--- a/src/rmplan/cleanup.ts
+++ b/src/rmplan/cleanup.ts
@@ -1,0 +1,61 @@
+import { generateText } from 'ai';
+import { createModel } from '../common/model_factory.js';
+import { planExampleFormatGeneric } from './prompt.js';
+
+function cleanupPrompt(input: string) {
+  const exampleFormat = planExampleFormatGeneric
+    .split('\n')
+    .map((line) => '  ' + line)
+    .join('\n');
+
+  return `You are a YAML formatting expert. Your task is to clean up and format the given text into valid YAML. Pay close attention to the structure, indentation, and proper use of quotes and multi-line string formatting.
+
+Here is the text that needs to be converted to valid YAML:
+
+<input_text>
+${input}
+</input_text>
+
+Before formatting the YAML, analyze the input and plan your approach inside yaml_analysis tags:
+
+1. Identify and list key-value pairs from the input text
+2. Note any structural inconsistencies or formatting issues
+3. Plan how to reorganize the content to fit the required YAML structure
+4. Identify the overall structure of the YAML
+5. List any strings that need to be quoted
+6. Identify any multi-line strings that require the pipe character
+7. Note any indentation issues that need to be corrected
+8. Check if the structure matches the expected format (goal, details, tasks)
+9. Plan how to handle any missing or extra fields
+10. Count the number of tasks in the input
+
+Now, format the input text into valid YAML according to the following guidelines:
+
+1. Ensure the YAML structure matches this format:
+   \`\`\`yaml
+${exampleFormat}
+   \`\`\`
+
+2. Use quotes for strings containing special characters or when necessary to avoid YAML parsing errors.
+
+3. For multi-line strings, use the pipe character (|) followed by the indented text on subsequent lines.
+
+4. Ensure proper indentation: Use 2 spaces for each level of indentation.
+
+5. For lists (such as 'files' and 'steps'), use a hyphen (-) followed by a space for each item.
+
+6. If any required fields are missing in the input, include them with empty values.
+
+7. Remove any fields that don't match the expected structure.
+
+Output only the cleaned and formatted YAML, without any additional explanations or comments.`;
+}
+
+export async function cleanupYaml(input: string) {
+  const prompt = cleanupPrompt(input);
+  const result = await generateText({
+    model: createModel('gemini-2.5-flash-preview-04-17'),
+    prompt,
+  });
+  return result.text;
+}

--- a/src/rmplan/planSchema.ts
+++ b/src/rmplan/planSchema.ts
@@ -17,3 +17,5 @@ export const planSchema = z.object({
     })
   ),
 });
+
+export type PlanSchema = z.infer<typeof planSchema>;

--- a/src/rmplan/planSchema.ts
+++ b/src/rmplan/planSchema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+export const planSchema = z.object({
+  goal: z.string(),
+  details: z.string(),
+  tasks: z.array(
+    z.object({
+      title: z.string(),
+      description: z.string(),
+      files: z.array(z.string()),
+      steps: z.array(
+        z.object({
+          prompt: z.string(),
+          done: z.boolean().default(false),
+        })
+      ),
+    })
+  ),
+});

--- a/src/rmplan/prompt.ts
+++ b/src/rmplan/prompt.ts
@@ -13,6 +13,16 @@ tasks:
           describing what to do.
       - prompt: Another step`;
 
+const planExampleFormat2 = `goal: [single-line string]
+details: [single-line or multi-line string]
+tasks:
+  - title: [single-line string]
+    description: [single-line or multi-line string]
+    files:
+      - [list of file paths]
+    steps:
+      - prompt: [single-line or multi-line string]`;
+
 export function planPrompt(plan: string) {
   // This is a variant of the planning prompt from https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/
   return `This is a project plan for an upcoming feature.
@@ -37,7 +47,7 @@ When generating the final output with the prompts, output an overall goal, proje
 <formatting>
 Use the following YAML format for your final prompt output:
 \`\`\`yaml
-${planExampleFormat}
+${planExampleFormat2}
 \`\`\`
 </formatting>
 `;

--- a/src/rmplan/prompt.ts
+++ b/src/rmplan/prompt.ts
@@ -1,3 +1,18 @@
+export const planExampleFormat = `
+goal: the goal of the project plan
+details: details and analysis about the plan
+tasks:
+  - title: the title of a task
+    description: more information about the task
+    files:
+      - src/index.ts
+      - other files
+    steps:
+      - prompt: |
+          This is a multiline prompt
+          describing what to do.
+      - prompt: Another step`;
+
 export function planPrompt(plan: string) {
   // This is a variant of the planning prompt from https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/
   return `This is a project plan for an upcoming feature.
@@ -22,19 +37,7 @@ When generating the final output with the prompts, output an overall goal, proje
 <formatting>
 Use the following YAML format for your final prompt output:
 \`\`\`yaml
-goal: the goal of the project plan
-details: details and analysis about the plan
-tasks:
-  - title: the title of a task
-    description: more information about the task
-    files:
-      - src/index.ts
-      - other files
-    steps:
-      - prompt: |
-          This is a multiline prompt
-          describing what to do.
-      - prompt: Another step
+${planExampleFormat}
 \`\`\`
 </formatting>
 `;

--- a/src/rmplan/prompt.ts
+++ b/src/rmplan/prompt.ts
@@ -13,7 +13,7 @@ tasks:
           describing what to do.
       - prompt: Another step`;
 
-const planExampleFormat2 = `goal: [single-line string]
+export const planExampleFormatGeneric = `goal: [single-line string]
 details: [single-line or multi-line string]
 tasks:
   - title: [single-line string]
@@ -47,7 +47,7 @@ When generating the final output with the prompts, output an overall goal, proje
 <formatting>
 Use the following YAML format for your final prompt output:
 \`\`\`yaml
-${planExampleFormat2}
+${planExampleFormatGeneric}
 \`\`\`
 </formatting>
 `;

--- a/src/rmplan/prompt.ts
+++ b/src/rmplan/prompt.ts
@@ -1,0 +1,41 @@
+export function planPrompt(plan: string) {
+  // This is a variant of the planning prompt from https://harper.blog/2025/02/16/my-llm-codegen-workflow-atm/
+  return `This is a project plan for an upcoming feature.
+
+# Project Plan
+
+${plan}
+
+# Plan Creation
+
+Please think about how to accomplish the task and create a detailed, step-by-step blueprint for it. The blueprint should
+work in the context of the provided codebase. Examine the provided codebase and identify which files need to be edited for each step.
+
+Break it down into small, iterative chunks that build on each other. Look at these chunks and then go another round to break it into small steps. Review the results and make sure that the steps are small enough to be implemented safely with strong testing, but big enough to move the project forward. Iterate until you feel that the steps are right sized for this project.
+
+From here you should have the foundation to provide a series of prompts for a code-generation LLM that will implement each step in a test-driven manner. Prioritize best practices, incremental progress, and early testing, ensuring no big jumps in complexity at any stage. Make sure that each prompt builds on the previous prompts, and ends with everything wired together. There should be no hanging or orphaned code that isn't integrated into a previous step.
+
+The goal is to output prompts, but context, etc is important as well. Remember when creating a prompt that the model executing it may not have all the context you have and will not be as smart as you, so you need to be very detailed and include plenty of information about which files to edit, what to do and how to do it.
+
+When generating the final output with the prompts, output an overall goal, project details, and then a list of tasks. Each task should have a list of files to edit and a list of steps, where each step is part of the prompt. The tool that consumes this YAML will join the data for a task together into a single prompt.
+
+<formatting>
+Use the following YAML format for your final prompt output:
+\`\`\`yaml
+goal: the goal of the project plan
+details: details and analysis about the plan
+tasks:
+  - title: the title of a task
+    description: more information about the task
+    files:
+      - src/index.ts
+      - other files
+    steps:
+      - prompt: |
+          This is a multiline prompt
+          describing what to do.
+      - prompt: Another step
+\`\`\`
+</formatting>
+`;
+}

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -1,26 +1,4 @@
 #!/usr/bin/env bun
-import { z } from 'zod';
+import { planSchema } from './planSchema.js';
 import { planPrompt } from './prompt.js';
 
-const planSchema = z.object({
-  goal: z.string(),
-  details: z.string(),
-  tasks: z.array(
-    z.object({
-      title: z.string(),
-      description: z.string(),
-      files: z.array(z.string()),
-      steps: z.array(
-        z.object({
-          prompt: z.string(),
-          done: z.boolean().default(false),
-        })
-      ),
-    })
-  ),
-});
-
-const file = process.argv[2];
-const plan = await Bun.file(file).text();
-const parsedPlan = planPrompt(plan);
-console.log(parsedPlan);

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -317,13 +317,24 @@ program
         );
       } else {
         // Otherwise, prompt user to select steps
+        let maxWidth = process.stdout.columns - 12;
         selectedIndex = await select({
           message: 'Run up to which step?',
-          choices: pendingSteps.map((step, index) => ({
-            name: `[${index + 1}] ${step.prompt.split('\n')[0]}...`,
-            description: step.prompt,
-            value: index,
-          })),
+          choices: pendingSteps.map((step, index) => {
+            let lines = step.prompt.split('\n');
+            let name: string;
+            if (lines[0].length > maxWidth) {
+              name = `[${index + 1}] ${lines[0].slice(0, maxWidth)}...`;
+            } else {
+              name = `[${index + 1}] ${lines[0]}`;
+            }
+
+            return {
+              name,
+              description: '\n' + step.prompt,
+              value: index,
+            };
+          }),
         });
       }
 

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -149,8 +149,23 @@ program
   .command('done <planFile>')
   .description('Mark the next step/task in a plan YAML as done')
   .option('--task', 'Mark all steps in the current task as done')
-  .action((planFile, options) => {
-    console.log('done...');
+  .action(async (planFile, options) => {
+    try {
+      const fileContent = await Bun.file(planFile).text();
+      const parsed = yaml.parse(fileContent);
+      const result = planSchema.safeParse(parsed);
+      
+      if (!result.success) {
+        console.error('Validation errors:', result.error);
+        process.exit(1);
+      }
+      
+      const planData = result.data;
+      console.log('Plan loaded successfully');
+    } catch (err) {
+      console.error('Failed to process plan file:', err);
+      process.exit(1);
+    }
   });
 
 program

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
 import { planSchema } from './planSchema.js';
+import { getInstructionsFromEditor } from '../rmfilter/instructions.js';
 import { planPrompt } from './prompt.js';
 import { Command } from 'commander';
 
@@ -25,8 +26,30 @@ program
       process.exit(1);
     }
 
-    // TODO: Pass rmfilterArgs to rmfilter logic
-    console.log('generate...');
+    let planText: string | undefined;
+
+    if (options.plan) {
+      try {
+        planText = await Bun.file(options.plan).text();
+      } catch (err) {
+        console.error(`Failed to read plan file: ${options.plan}`);
+        process.exit(1);
+      }
+    } else if (options.planEditor) {
+      try {
+        planText = await getInstructionsFromEditor('rmplan-plan.md');
+        if (!planText || !planText.trim()) {
+          console.error('No plan text was provided from the editor.');
+          process.exit(1);
+        }
+      } catch (err) {
+        console.error('Failed to get plan from editor:', err);
+        process.exit(1);
+      }
+    }
+
+    // planText now contains the loaded plan
+    console.log('Loaded plan text:', planText);
     console.log('Options:', options);
     console.log('rmfilter args:', rmfilterArgs);
   });

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -11,6 +11,7 @@ import { Command } from 'commander';
 import os from 'os';
 import path from 'path';
 import { cleanupYaml } from './cleanup.js';
+import { select } from '@inquirer/prompts';
 
 interface PendingTaskResult {
   task: PlanSchema['tasks'][number];
@@ -234,7 +235,26 @@ program
       const completedSteps = activeTask.steps.filter((step) => step.done);
       const pendingSteps = activeTask.steps.filter((step) => !step.done);
 
-      console.log('Found pending steps in task:', activeTask.title);
+      if (pendingSteps.length === 0) {
+        console.log('No pending steps in the current task.');
+        process.exit(0);
+      }
+
+      // Prompt user to select steps
+      const selectedIndex = await select({
+        message: 'Run up to which step?',
+        choices: pendingSteps.map((step, index) => ({
+          name: `[${index + 1}] ${step.prompt.split('\n')[0]}...`,
+          description: step.prompt,
+          value: index,
+        })),
+      });
+      const selectedPendingSteps = pendingSteps.slice(0, selectedIndex + 1);
+      // You can now use selectedSteps as needed for the next action
+      console.log(
+        'Selected steps:',
+        selectedPendingSteps.map((s) => s.prompt)
+      );
     } catch (err) {
       console.error('Failed to process plan file:', err);
       process.exit(1);

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -230,6 +230,10 @@ program
       }
       const activeTask = result.task;
 
+      // Separate completed and pending steps
+      const completedSteps = activeTask.steps.filter((step) => step.done);
+      const pendingSteps = activeTask.steps.filter((step) => !step.done);
+
       console.log('Found pending steps in task:', activeTask.title);
     } catch (err) {
       console.error('Failed to process plan file:', err);

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -202,7 +202,7 @@ program
         for (const step of pendingSteps) {
           step.done = true;
         }
-        output.push('Marked all steps in task done');
+        output.push('Marked all steps in task done\n');
         output.push(task.title);
 
         for (let i = 0; i < pendingSteps.length; i++) {
@@ -211,10 +211,13 @@ program
         }
       } else {
         task.steps[pending.stepIndex].done = true;
-        console.log(`Marked task '${task.title}' step ${pending.stepIndex + 1} done`);
 
-        output.push(`Marked step done`);
-        output.push(`${task.title} step ${pending.stepIndex + 1}`);
+        output.push(`Marked step done\n`);
+        if (task.steps.length > 1) {
+          output.push(`${task.title} step ${pending.stepIndex + 1}`);
+        } else {
+          output.push(`${task.title}`);
+        }
         output.push(`\n${task.steps[pending.stepIndex].prompt}`);
       }
 

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -131,6 +131,13 @@ program
       process.exit(1);
     }
     validatedPlan = result.data;
+
+    const outputYaml = yaml.stringify(validatedPlan);
+    if (options.output) {
+      await Bun.write(options.output, outputYaml);
+    } else {
+      console.log(outputYaml);
+    }
   });
 
 program

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -304,7 +304,7 @@ program
       );
 
       if (options.previous && completedSteps.length > 0) {
-        promptParts.push('## Completed Steps in this Task:');
+        promptParts.push('## Completed Subtasks in this Task:');
         completedSteps.forEach((step, index) => {
           promptParts.push(`- [DONE] ${step.prompt.split('\\n')[0]}...`);
         });
@@ -312,14 +312,14 @@ program
 
       if (!options.rmfilter) {
         promptParts.push(
-          '## Relevant Files\n\nThese are relevant files for the next steps. If you think additional files are relevant, you can update them as well.'
+          '## Relevant Files\n\nThese are relevant files for the next subtasks. If you think additional files are relevant, you can update them as well.'
         );
         files.forEach((file) => {
           promptParts.push(`- ${file}`);
         });
       }
 
-      promptParts.push('\n## Selected Next Steps to Implement:\n');
+      promptParts.push('\n## Selected Next Subtasks to Implement:\n');
       selectedPendingSteps.forEach((step, index) => {
         promptParts.push(`- [TODO ${index + 1}] ${step.prompt}`);
       });

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -3,6 +3,7 @@ import { planSchema } from './planSchema.js';
 import { logSpawn } from '../rmfilter/utils.js';
 import { getInstructionsFromEditor } from '../rmfilter/instructions.js';
 import { planPrompt } from './prompt.js';
+import clipboardy from 'clipboardy';
 import { Command } from 'commander';
 import os from 'os';
 import path from 'path';
@@ -86,10 +87,20 @@ program
   });
 
 program
-  .command('extract')
+  .command('extract [inputFile]')
   .description('Extract and validate a plan YAML from text')
-  .action(() => {
-    console.log('extract...');
+  .option('-o, --output <outputFile>', 'Write result to a file instead of stdout')
+  .action(async (inputFile, options) => {
+    let inputText: string;
+    if (inputFile) {
+      inputText = await Bun.file(inputFile).text();
+    } else if (!process.stdin.isTTY) {
+      inputText = await Bun.stdin.text();
+    } else {
+      inputText = await clipboardy.read();
+    }
+    console.log('inputText:', inputText);
+    console.log('outputFile:', options.output);
   });
 
 program

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env bun
+import { z } from 'zod';
+import { planPrompt } from './prompt.js';
+
+const planSchema = z.object({
+  goal: z.string(),
+  details: z.string(),
+  tasks: z.array(
+    z.object({
+      title: z.string(),
+      description: z.string(),
+      files: z.array(z.string()),
+      steps: z.array(
+        z.object({
+          prompt: z.string(),
+          done: z.boolean().default(false),
+        })
+      ),
+    })
+  ),
+});
+
+const file = process.argv[2];
+const plan = await Bun.file(file).text();
+const parsedPlan = planPrompt(plan);
+console.log(parsedPlan);

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -250,11 +250,27 @@ program
         })),
       });
       const selectedPendingSteps = pendingSteps.slice(0, selectedIndex + 1);
-      // You can now use selectedSteps as needed for the next action
-      console.log(
-        'Selected steps:',
-        selectedPendingSteps.map((s) => s.prompt)
-      );
+      // Build the LLM prompt
+      const promptParts: string[] = [];
+      promptParts.push(`Goal: ${planData.goal}\nDetails: ${planData.details}\n`);
+      promptParts.push(`Current Task: ${activeTask.title}\nDescription: ${activeTask.description}\n`);
+
+      if (completedSteps.length > 0) {
+        promptParts.push('Completed Steps in this Task:');
+        completedSteps.forEach((step, index) => {
+          promptParts.push(`- [DONE] ${step.prompt.split('\\n')[0]}...`);
+        });
+      }
+
+      promptParts.push('\nSelected Next Steps to Implement:');
+      selectedPendingSteps.forEach((step, index) => {
+        promptParts.push(`- [TODO ${index + 1}] ${step.prompt}`);
+      });
+
+      const llmPrompt = promptParts.join('\n');
+      console.log('\n----- LLM PROMPT -----\n');
+      console.log(llmPrompt);
+      console.log('\n---------------------\n');
     } catch (err) {
       console.error('Failed to process plan file:', err);
       process.exit(1);

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -146,9 +146,10 @@ program
   });
 
 program
-  .command('done')
+  .command('done <planFile>')
   .description('Mark the next step/task in a plan YAML as done')
-  .action(() => {
+  .option('--task', 'Mark all steps in the current task as done')
+  .action((planFile, options) => {
     console.log('done...');
   });
 

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -1,4 +1,39 @@
 #!/usr/bin/env bun
 import { planSchema } from './planSchema.js';
 import { planPrompt } from './prompt.js';
+import { Command } from 'commander';
 
+const program = new Command();
+program
+  .name('rmplan')
+  .description('Generate and execute task plans using LLMs');
+
+program
+  .command('generate')
+  .description('Generate planning prompt and context for a task')
+  .action(() => {
+    console.log('generate...');
+  });
+
+program
+  .command('extract')
+  .description('Extract and validate a plan YAML from text')
+  .action(() => {
+    console.log('extract...');
+  });
+
+program
+  .command('done')
+  .description('Mark the next step/task in a plan YAML as done')
+  .action(() => {
+    console.log('done...');
+  });
+
+program
+  .command('next')
+  .description('Prepare the next step(s) from a plan YAML for execution')
+  .action(() => {
+    console.log('next...');
+  });
+
+program.parse(process.argv);

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -10,6 +10,7 @@ import clipboardy from 'clipboardy';
 import { Command } from 'commander';
 import os from 'os';
 import path from 'path';
+import { cleanupYaml } from './cleanup.js';
 
 const program = new Command();
 program.name('rmplan').description('Generate and execute task plans using LLMs');
@@ -117,22 +118,9 @@ program
     if (!validatedPlan) {
       // Use Gemini Flash to clean up the text to valid YAML
       console.warn('YAML parsing failed, attempting LLM cleanup...');
-      const model = createModel('gemini-2.5-flash-preview-04-17');
-      const prompt = `Clean up the following text into valid YAML. Output only the YAML, no explanation.
-      
-Look especially at places where strings need to be quoted, or the pipe character for multi-line strings is missing.
+      const result = await cleanupYaml(inputText);
 
-The expected YAML format is:
-${planExampleFormat}
-
-The YAML to clean up is:
----\n${inputText}\n---`;
-      const result = await generateText({
-        model,
-        prompt,
-      });
-
-      let cleanedYaml = result.text;
+      let cleanedYaml = result;
       const match = cleanedYaml.match(/```yaml\n([\s\S]*?)\n```/i);
       let rawYaml = match ? match[1] : cleanedYaml;
       try {

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -213,9 +213,9 @@ program
   });
 
 program
-  .command('next')
+  .command('next <planFile>')
   .description('Prepare the next step(s) from a plan YAML for execution')
-  .action(() => {
+  .action(async (planFile) => {
     console.log('next...');
   });
 

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -11,8 +11,24 @@ program
 program
   .command('generate')
   .description('Generate planning prompt and context for a task')
-  .action(() => {
+  .option('--plan <file>', 'YAML plan file to use')
+  .option('--plan-editor', 'Open plan in editor')
+  .allowUnknownOption(true)
+  .action((options, command) => {
+    // Find '--' in process.argv to get extra args for rmfilter
+    const doubleDashIdx = process.argv.indexOf('--');
+    const rmfilterArgs = doubleDashIdx !== -1 ? process.argv.slice(doubleDashIdx + 1) : [];
+
+    // Manual conflict check for --plan and --plan-editor
+    if ((options.plan && options.planEditor) || (!options.plan && !options.planEditor)) {
+      console.error('You must provide either --plan <file> or --plan-editor (but not both).');
+      process.exit(1);
+    }
+
+    // TODO: Pass rmfilterArgs to rmfilter logic
     console.log('generate...');
+    console.log('Options:', options);
+    console.log('rmfilter args:', rmfilterArgs);
   });
 
 program

--- a/tasks/0002-rmplan-full.md
+++ b/tasks/0002-rmplan-full.md
@@ -1,0 +1,72 @@
+This is a project plan for an upcoming feature.
+
+# Project Plan
+
+This is a new utility called rmplan, which is used for generating plans for a given task and then executing that plan.
+
+## Commands
+
+### Generate
+ 
+The `generate` command generates a planning prompt and context for a given task by inserting the plan into the planning prompt at rmfind/prompt.ts,
+and then calling rmfilter to generate the context. It should support --plan and --plan-editor arguments, similar to the rmfilter
+command's --instruction and --instruction-editor arguments.
+
+Once the planning prompt is created, take all the other arguments after the first `--` in the command line and pass them
+to the rmfilter command, along with the `--bare` flag and the relevant `--instructions @tempfile.md` argument to include the planning
+prompt. You can save the planning prompt to a temporary file.
+
+### Extract
+
+The `extract` command takes a response from the language model which should contain a YAML file that complies with the
+`planSchema`. The response may include other text so it should find the relevant portion to parse. Then output to stdout
+or write it to a file if the `-o` argument is provided.
+
+### Done
+
+The `done` command takes a YAML file as an argument that complies with `planSchema`. Find the next unfinished step and mark it as done.
+If the --task argument is provided, find the next unfinished step and mark all the steps in that task as done.
+
+### Next
+
+The `next` command takes a YAML file as an argument that complies with `planSchema`. 
+
+1. Find the next unfinished task to work on.
+2. Look at all the unfinished steps in that task.
+3. Show the unfinished steps, and allow the user to choose up to which step should go into the prompt. 
+4. Output the combined prompt with the files, steps and other relevant information from the task and top-level context. Include
+   a bit of information about previous steps that were done.
+
+
+# Plan Creation
+
+Please think about how to accomplish the task and create a detailed, step-by-step blueprint for it. The blueprint should
+work in the context of the provided codebase. Examine the provided codebase and identify which files need to be edited for each step.
+
+Break it down into small, iterative chunks that build on each other. Look at these chunks and then go another round to break it into small steps. Review the results and make sure that the steps are small enough to be implemented safely with strong testing, but big enough to move the project forward. Iterate until you feel that the steps are right sized for this project.
+
+From here you should have the foundation to provide a series of prompts for a code-generation LLM that will implement each step in a test-driven manner. Prioritize best practices, incremental progress, and early testing, ensuring no big jumps in complexity at any stage. Make sure that each prompt builds on the previous prompts, and ends with everything wired together. There should be no hanging or orphaned code that isn't integrated into a previous step.
+
+The goal is to output prompts, but context, etc is important as well. Remember when creating a prompt that the model executing it may not have all the context you have and will not be as smart as you, so you need to be very detailed and include plenty of information about which files to edit, what to do and how to do it.
+
+When generating the final output with the prompts, output an overall goal, project details, and then a list of tasks. Each task should have a list of files to edit and a list of steps, where each step is part of the prompt. The tool that consumes this YAML will join the data for a task together into a single prompt.
+
+<formatting>
+Use the following YAML format for your final prompt output:
+```yaml
+goal: the goal of the project plan
+details: details and analysis about the plan
+tasks:
+  - title: the title of a task
+    description: more information about the task
+    files:
+      - src/index.ts
+      - other files
+    steps:
+      - prompt: |
+          This is a multiline prompt
+          describing what to do.
+      - prompt: Another step
+```
+</formatting>
+

--- a/tasks/0002-rmplan.md
+++ b/tasks/0002-rmplan.md
@@ -1,0 +1,34 @@
+This is a new utility called rmplan, which is used for generating plans for a given task and then executing that plan.
+
+## Commands
+
+### Generate
+ 
+The `generate` command generates a planning prompt and context for a given task by inserting the plan into the planning prompt at rmfind/prompt.ts,
+and then calling rmfilter to generate the context. It should support --plan and --plan-editor arguments, similar to the rmfilter
+command's --instruction and --instruction-editor arguments.
+
+Once the planning prompt is created, take all the other arguments after the first `--` in the command line and pass them
+to the rmfilter command, along with the `--bare` flag and the relevant `--instructions @tempfile.md` argument to include the planning
+prompt. You can save the planning prompt to a temporary file.
+
+### Extract
+
+The `extract` command takes a response from the language model which should contain a YAML file that complies with the
+`planSchema`. The response may include other text so it should find the relevant portion to parse. Then output to stdout
+or write it to a file if the `-o` argument is provided.
+
+### Done
+
+The `done` command takes a YAML file as an argument that complies with `planSchema`. Find the next unfinished step and mark it as done.
+If the --task argument is provided, find the next unfinished step and mark all the steps in that task as done.
+
+### Next
+
+The `next` command takes a YAML file as an argument that complies with `planSchema`. 
+
+1. Find the next unfinished task to work on.
+2. Look at all the unfinished steps in that task.
+3. Show the unfinished steps, and allow the user to choose up to which step should go into the prompt. 
+4. Output the combined prompt with the files, steps and other relevant information from the task and top-level context. Include
+   a bit of information about previous steps that were done.

--- a/tasks/0002-rmplan.yml
+++ b/tasks/0002-rmplan.yml
@@ -115,23 +115,16 @@ tasks:
           2.  Add an optional argument `[inputFile]` to specify an input file. If not provided, assume input comes from stdin.
           3.  Add an option `-o, --output <outputFile>` for writing the result to a file instead of stdout.
           4.  Update the `.action()` function to accept the `inputFile` argument and `options`.
+        done: true
       - prompt: |
           Implement input reading for the `extract` subcommand.
           1.  Inside the `extract` action:
           2.  Check if `inputFile` argument is provided.
           3.  If yes, read the content using `await Bun.file(inputFile).text()`.
-          4.  If no, read from stdin. You can use a helper function like:
-              ```typescript
-              async function readStdin(): Promise<string> {
-                const chunks = [];
-                for await (const chunk of Bun.stdin.stream()) {
-                  chunks.push(Buffer.from(chunk));
-                }
-                return Buffer.concat(chunks).toString('utf8');
-              }
-              const inputText = await readStdin();
-              ```
+          4.  If no, read from stdin if it is not a TTY. Else read from the clipboard using the clipboardy package. 
+              You can use `await Bun.stdin.text()` to read stdin.
           5.  Store the result in `inputText`.
+        done: true
       - prompt: |
           Implement YAML extraction, parsing, and validation.
           1.  Import `yaml` from the `yaml` package.
@@ -142,6 +135,7 @@ tasks:
           4.  Once a potential YAML object is parsed, validate it using `planSchema.safeParse(parsedObject)`.
           5.  If `safeParse` fails (`!result.success`), print the validation errors (`result.error`) to stderr and exit with a non-zero code.
           6.  If successful, store the validated data (`result.data`) in `validatedPlan`.
+        done: true
       - prompt: |
           Implement output handling for the `extract` subcommand.
           1.  Stringify the `validatedPlan` back into YAML format using `yaml.stringify(validatedPlan)`.

--- a/tasks/0002-rmplan.yml
+++ b/tasks/0002-rmplan.yml
@@ -23,6 +23,7 @@ tasks:
           4.  Import `planSchema` in `src/rmplan/rmplan.ts`.
           5.  Remove the old schema definition code from `src/rmplan/rmplan.ts`.
           6.  Keep the initial shebang and import for `planPrompt`. Remove the example file loading and parsing logic for now.
+        done: true
       - prompt: |
           Install necessary dependencies and set up the basic CLI structure using `commander`.
           1.  Add `commander` and `yaml` as dependencies using `bun add commander yaml`.
@@ -36,6 +37,7 @@ tasks:
               - `next`: `.command('next').description('Prepare the next step(s) from a plan YAML for execution')`
           6.  Add placeholder `.action(() => { console.log('...'); })` calls for each subcommand for now.
           7.  Add `program.parse(process.argv);` at the end of the file.
+        done: true
       - prompt: |
           Configure the `rmplan` executable in `package.json`.
           1.  In `package.json`, ensure there is a `bin` field.

--- a/tasks/0002-rmplan.yml
+++ b/tasks/0002-rmplan.yml
@@ -209,7 +209,7 @@ tasks:
           8.  Test that the modified data is written back correctly (mock `Bun.write` and check the content passed to it).
 
   - title: Implement `next` Subcommand (Core Logic)
-    description: "Implement the non-interactive parts of the `next` subcommand: loading the plan, finding the next task/steps, and preparing data for prompt generation."
+    description: 'Implement the non-interactive parts of the `next` subcommand: loading the plan, finding the next task/steps, and preparing data for prompt generation.'
     files:
       - src/rmplan/rmplan.ts
       - src/rmplan/planSchema.ts
@@ -219,6 +219,7 @@ tasks:
           1.  Target the `.command('next')` definition.
           2.  Add a required argument `<planFile>` for the path to the plan YAML file.
           3.  Update the `.action()` function to accept `planFile`.
+        done: true
       - prompt: |
           Implement plan loading, parsing, validation, and finding the next active task.
           1.  Inside the `next` action, load, parse, and validate the `planFile` similarly to the `done` command. Store valid data in `planData`.
@@ -227,6 +228,7 @@ tasks:
           4.  For each task, check if *any* step within `task.steps` has `done === false` using `task.steps.some(step => !step.done)`.
           5.  If such a task is found, assign it to `activeTask`, store its index `i` in `activeTaskIndex`, and `break` the loop.
           6.  If after the loop `activeTask` is still `null`, print "No pending steps found in the plan." and exit.
+        done: true
       - prompt: |
           Identify completed and pending steps within the active task.
           1.  Assuming `activeTask` is found:
@@ -234,6 +236,7 @@ tasks:
           3.  Iterate through `activeTask.steps`.
           4.  If `step.done` is true, add it to `completedSteps`.
           5.  If `step.done` is false, add it to `pendingSteps`.
+        done: true
       - prompt: |
           Add tests for the `next` subcommand's core logic.
           1.  In `src/rmplan/rmplan.test.ts`, add tests for `next`.
@@ -272,6 +275,7 @@ tasks:
               const selectedPendingSteps = answers.selectedSteps; // Array of selected step objects
               ```
           6.  Store the result in `selectedPendingSteps`.
+        done: true
       - prompt: |
           Construct the final prompt for the LLM.
           1.  Create a prompt string builder or array.
@@ -290,6 +294,7 @@ tasks:
               selectedPendingSteps.forEach((step, index) => promptParts.push(`- [TODO ${index + 1}] ${step.prompt}`));
               ```
           6.  Join the prompt parts into a single string `llmPrompt`.
+        done: true
       - prompt: |
           Implement temporary file handling and the call to `rmfilter` for the `next` subcommand.
           1.  Write the generated `llmPrompt` to a temporary file (similar to the `generate` command). Use try/finally for cleanup.
@@ -298,6 +303,7 @@ tasks:
           4.  Execute `rmfilter` using `logSpawn` with inherited stdio.
           5.  Await completion and check the exit code.
           6.  Clean up the temporary file in the `finally` block.
+        done: true
       - prompt: |
           Add tests for the `next` subcommand's interaction and `rmfilter` call.
           1.  In `src/rmplan/rmplan.test.ts`:
@@ -305,4 +311,3 @@ tasks:
           3.  Verify that the generated LLM prompt string contains the correct goal, details, task info, completed steps summary, and *only* the selected pending steps.
           4.  Mock `Bun.write` and `Bun.file().unlink()` for temp file checks.
           5.  Mock `logSpawn` and assert that `rmfilter` is called with the correct arguments: the task's files, `--bare`, and `--instructions @<tempfile>`.
-

--- a/tasks/0002-rmplan.yml
+++ b/tasks/0002-rmplan.yml
@@ -1,0 +1,301 @@
+goal: Create a new command-line utility `rmplan` for generating and executing task plans using an LLM.
+details: |
+  The `rmplan` tool will integrate with the existing `rmfilter` utility. It provides subcommands to:
+  1.  `generate`: Create an initial planning prompt and context for a task description using `rmfilter`.
+  2.  `extract`: Parse a structured plan (YAML) from LLM output.
+  3.  `done`: Mark steps or entire tasks in a plan YAML file as completed.
+  4.  `next`: Interactively select the next steps from a plan YAML file and generate context using `rmfilter` to execute them.
+  The tool will use a defined Zod schema (`planSchema`) for plan validation and rely on libraries like `commander` for CLI structure, `yaml` for parsing/stringifying, and potentially `inquirer` for user interaction in the `next` command. Existing utilities from `llmutils` like argument parsing, file handling, and subprocess execution (`logSpawn`) should be reused where possible.
+tasks:
+  - title: Setup Basic CLI Structure and Update Schema
+    description: Initialize the `rmplan` command structure using `commander`, define subcommands, add dependencies, and update the `planSchema` with the `done` field.
+    files:
+      - src/rmplan/rmplan.ts
+      - package.json
+      - tsconfig.json # (Potentially for build configuration)
+      - src/rmplan/planSchema.ts # Extract schema to its own file for clarity
+    steps:
+      - prompt: |
+          Refactor `src/rmplan/rmplan.ts` to define the `planSchema`.
+          1.  Move the existing `planSchema` Zod object definition from `src/rmplan/rmplan.ts` into a new file `src/rmplan/planSchema.ts`.
+          2.  Modify the `step` object within the `planSchema` in `src/rmplan/planSchema.ts` to include a `done` field: `done: z.boolean().default(false)`.
+          3.  Export `planSchema` from `src/rmplan/planSchema.ts`.
+          4.  Import `planSchema` in `src/rmplan/rmplan.ts`.
+          5.  Remove the old schema definition code from `src/rmplan/rmplan.ts`.
+          6.  Keep the initial shebang and import for `planPrompt`. Remove the example file loading and parsing logic for now.
+      - prompt: |
+          Install necessary dependencies and set up the basic CLI structure using `commander`.
+          1.  Add `commander` and `yaml` as dependencies using `bun add commander yaml`.
+          2.  In `src/rmplan/rmplan.ts`, import `Command` from `commander`.
+          3.  Instantiate the main program: `const program = new Command();`.
+          4.  Set the program name and description: `program.name('rmplan').description('Generate and execute task plans using LLMs');`.
+          5.  Define the four subcommands (`generate`, `extract`, `done`, `next`) using `program.command()`:
+              - `generate`: `.command('generate').description('Generate planning prompt and context for a task')`
+              - `extract`: `.command('extract').description('Extract and validate a plan YAML from text')`
+              - `done`: `.command('done').description('Mark the next step/task in a plan YAML as done')`
+              - `next`: `.command('next').description('Prepare the next step(s) from a plan YAML for execution')`
+          6.  Add placeholder `.action(() => { console.log('...'); })` calls for each subcommand for now.
+          7.  Add `program.parse(process.argv);` at the end of the file.
+      - prompt: |
+          Configure the `rmplan` executable in `package.json`.
+          1.  In `package.json`, ensure there is a `bin` field.
+          2.  Add an entry for `rmplan`: `"rmplan": "src/rmplan/rmplan.ts"`.
+          3.  Run `bun install` to link the binary.
+          4.  Verify you can run `rmplan --help` and see the basic structure and subcommands.
+      - prompt: |
+          Add basic integration tests for the CLI structure.
+          1.  Create a test file, e.g., `src/rmplan/rmplan.test.ts`.
+          2.  Add tests that execute `rmplan --help`, `rmplan generate --help`, etc. (using `Bun.spawnSync` or similar) and assert that the command runs without error and prints help output. This verifies the basic `commander` setup.
+
+  - title: Implement `generate` Subcommand
+    description: Implement the logic for the `generate` subcommand, including argument handling, prompt generation, temporary file usage, and calling `rmfilter`.
+    files:
+      - src/rmplan/rmplan.ts
+      - src/rmplan/prompt.ts
+      - src/rmfilter/instructions.ts # To potentially reuse getInstructionsFromEditor
+      - src/rmfilter/utils.ts # To use logSpawn
+    steps:
+      - prompt: |
+          Define arguments and options for the `generate` subcommand in `src/rmplan/rmplan.ts`.
+          1.  Target the `.command('generate')` definition.
+          2.  Add options `--plan <file>` and `--plan-editor`. Use `.option()` for these. Make them conflict (a user should provide one or the other, or maybe neither if we allow piping later, but let's require one for now). You might need custom logic for this check later.
+          3.  Allow arbitrary arguments after `--` to be passed to `rmfilter`. Commander can handle this using `.allowUnknownOption().parseOptions(process.argv)`. You'll need to manually find the index of `--` and slice the args.
+          4.  Update the `.action()` function for `generate` to accept `options` and `command` (which contains the arguments).
+      - prompt: |
+          Implement the plan loading logic for the `generate` subcommand.
+          1.  Inside the `generate` action, check if `--plan` or `--plan-editor` was provided. Exit with an error if neither is present.
+          2.  If `--plan <file>` is used, read the content of the specified file using `Bun.file(options.plan).text()`.
+          3.  If `--plan-editor` is used:
+              - Import `getInstructionsFromEditor` from `src/rmfilter/instructions.ts`.
+              - Call `await getInstructionsFromEditor('rmplan-plan.md')` (use a specific filename) to get the plan text from the user's editor.
+              - Handle potential errors (e.g., empty input).
+          4.  Store the loaded plan text in a variable `planText`.
+      - prompt: |
+          Implement the prompt generation and temporary file handling.
+          1.  Import `planPrompt` from `src/rmplan/prompt.ts`.
+          2.  Call `planPrompt(planText)` to get the full planning prompt string.
+          3.  Import `os` and `path`.
+          4.  Generate a unique temporary file path, e.g., `path.join(os.tmpdir(), \`rmplan-prompt-\${Date.now()}.md\`)`.
+          5.  Write the generated planning prompt string to this temporary file using `Bun.write()`. Use a try/finally block to ensure cleanup.
+      - prompt: |
+          Implement the logic to call `rmfilter`.
+          1.  Import `logSpawn` from `src/rmfilter/utils.ts`.
+          2.  Find the index of `--` in `process.argv`.
+          3.  Slice `process.argv` to get the arguments intended for `rmfilter` (those after `--`).
+          4.  Construct the argument list for `rmfilter`: `['rmfilter', ...rmfilterArgs, '--bare', '--instructions', \`@\${tempFilePath}\`]`.
+          5.  Use `logSpawn` to execute the `rmfilter` command. Ensure `stdio` is configured appropriately (likely `'inherit'` for `stdout`, `stderr`, `stdin`) so `rmfilter` interacts directly with the user's terminal or pipes.
+          6.  Await the completion of the `rmfilter` process using `await proc.exited`. Check the exit code for errors.
+          7.  Inside the `finally` block from the previous step, delete the temporary file using `Bun.file(tempFilePath).unlink()`.
+      - prompt: |
+          Add tests for the `generate` subcommand.
+          1.  In `src/rmplan/rmplan.test.ts`, add tests specifically for `generate`.
+          2.  Test argument parsing (`--plan`, `--plan-editor`).
+          3.  Mock `getInstructionsFromEditor` for the `--plan-editor` test.
+          4.  Mock file reading for the `--plan` test.
+          5.  Mock `Bun.write` and `Bun.file().unlink()` to verify temp file handling.
+          6.  Mock `logSpawn` to assert that `rmfilter` is called with the correct arguments (`--bare`, `--instructions @<tempfile>`, arguments after `--`).
+
+  - title: Implement `extract` Subcommand
+    description: Implement the logic for the `extract` subcommand to find, parse, validate, and output YAML plans from input text.
+    files:
+      - src/rmplan/rmplan.ts
+      - src/rmplan/planSchema.ts
+    steps:
+      - prompt: |
+          Define arguments and options for the `extract` subcommand in `src/rmplan/rmplan.ts`.
+          1.  Target the `.command('extract')` definition.
+          2.  Add an optional argument `[inputFile]` to specify an input file. If not provided, assume input comes from stdin.
+          3.  Add an option `-o, --output <outputFile>` for writing the result to a file instead of stdout.
+          4.  Update the `.action()` function to accept the `inputFile` argument and `options`.
+      - prompt: |
+          Implement input reading for the `extract` subcommand.
+          1.  Inside the `extract` action:
+          2.  Check if `inputFile` argument is provided.
+          3.  If yes, read the content using `await Bun.file(inputFile).text()`.
+          4.  If no, read from stdin. You can use a helper function like:
+              ```typescript
+              async function readStdin(): Promise<string> {
+                const chunks = [];
+                for await (const chunk of Bun.stdin.stream()) {
+                  chunks.push(Buffer.from(chunk));
+                }
+                return Buffer.concat(chunks).toString('utf8');
+              }
+              const inputText = await readStdin();
+              ```
+          5.  Store the result in `inputText`.
+      - prompt: |
+          Implement YAML extraction, parsing, and validation.
+          1.  Import `yaml` from the `yaml` package.
+          2.  Import `planSchema` from `src/rmplan/planSchema.ts`.
+          3.  Develop a strategy to find the YAML block within `inputText`. Start simple:
+              - Try parsing the entire `inputText` directly with `yaml.parse()`. If it succeeds, use the result.
+              - If that fails, use a regex to find blocks like `\`\`\`yaml\n(.*?)\n\`\`\`` (adjust flags like `s` for multiline). Extract the content and try parsing that. Add more robust extraction if needed later.
+          4.  Once a potential YAML object is parsed, validate it using `planSchema.safeParse(parsedObject)`.
+          5.  If `safeParse` fails (`!result.success`), print the validation errors (`result.error`) to stderr and exit with a non-zero code.
+          6.  If successful, store the validated data (`result.data`) in `validatedPlan`.
+      - prompt: |
+          Implement output handling for the `extract` subcommand.
+          1.  Stringify the `validatedPlan` back into YAML format using `yaml.stringify(validatedPlan)`.
+          2.  Check if the `options.output` file path was provided.
+          3.  If yes, write the stringified YAML to `options.output` using `Bun.write()`.
+          4.  If no, print the stringified YAML to stdout using `console.log()`.
+      - prompt: |
+          Add tests for the `extract` subcommand.
+          1.  In `src/rmplan/rmplan.test.ts`, add tests for `extract`.
+          2.  Test reading from a mocked file input.
+          3.  Test reading from mocked stdin.
+          4.  Test extracting YAML from input with surrounding text (using regex).
+          5.  Test successful parsing and validation against `planSchema`.
+          6.  Test handling of invalid YAML input.
+          7.  Test handling of valid YAML that doesn't match `planSchema`.
+          8.  Test outputting to stdout (check `console.log` mock or capture stdout).
+          9.  Test outputting to a file (mock `Bun.write`).
+
+  - title: Implement `done` Subcommand
+    description: Implement the logic for the `done` subcommand to load a plan, mark steps/tasks as done, and save the changes.
+    files:
+      - src/rmplan/rmplan.ts
+      - src/rmplan/planSchema.ts
+    steps:
+      - prompt: |
+          Define arguments and options for the `done` subcommand in `src/rmplan/rmplan.ts`.
+          1.  Target the `.command('done')` definition.
+          2.  Add a required argument `<planFile>` for the path to the plan YAML file.
+          3.  Add a boolean option `--task` using `.option('--task', 'Mark all steps in the current task as done')`.
+          4.  Update the `.action()` function to accept `planFile` and `options`.
+      - prompt: |
+          Implement file loading, parsing, and validation for the `done` subcommand.
+          1.  Import `yaml`.
+          2.  Import `planSchema`.
+          3.  Inside the `done` action, read the content of `planFile` using `Bun.file(planFile).text()`.
+          4.  Parse the content using `yaml.parse()`.
+          5.  Validate the parsed object using `planSchema.safeParse()`. Handle errors (print to stderr, exit). Store the valid data in `planData`.
+      - prompt: |
+          Implement the logic to find and mark the next step/task as done.
+          1.  Initialize variables `foundTaskIndex = -1`, `foundStepIndex = -1`.
+          2.  Iterate through `planData.tasks` using a `for` loop with index `i`.
+          3.  Inside the task loop, iterate through `planData.tasks[i].steps` using index `j`.
+          4.  Check if `planData.tasks[i].steps[j].done` is `false`.
+          5.  If it's the first unfinished step found (`foundTaskIndex === -1`), store `i` in `foundTaskIndex` and `j` in `foundStepIndex`.
+          6.  If the `--task` option is *not* set, `break` both loops immediately after finding the first unfinished step.
+          7.  If the `--task` option *is* set, continue the inner loop (steps loop) until it finishes for the `foundTaskIndex`. Then `break` the outer loop (tasks loop). This ensures we process all steps of the target task if needed but stop looking for other tasks.
+          8.  After the loops, check if `foundTaskIndex === -1`. If so, print "All steps are already done." and exit.
+          9.  If `options.task` is true:
+              - Iterate through all steps in `planData.tasks[foundTaskIndex].steps` and set `step.done = true` for each.
+          10. Else (`options.task` is false):
+              - Set `planData.tasks[foundTaskIndex].steps[foundStepIndex].done = true`.
+      - prompt: |
+          Implement saving the modified plan back to the file.
+          1.  Stringify the modified `planData` object back into YAML using `yaml.stringify()`.
+          2.  Write the updated YAML string back to the original `planFile` path using `Bun.write()`.
+          3.  Optionally print a confirmation message like "Marked step X in task Y as done." or "Marked task Y as done.".
+      - prompt: |
+          Add tests for the `done` subcommand.
+          1.  In `src/rmplan/rmplan.test.ts`, add tests for `done`.
+          2.  Prepare sample plan YAML data (as strings or objects).
+          3.  Test loading, parsing, validation failures.
+          4.  Test finding the first unfinished step correctly across multiple tasks.
+          5.  Test marking only the single next step as done (without `--task`). Verify the resulting object state.
+          6.  Test marking all steps within the correct task as done (with `--task`). Verify the object state.
+          7.  Test the case where all steps are already done.
+          8.  Test that the modified data is written back correctly (mock `Bun.write` and check the content passed to it).
+
+  - title: Implement `next` Subcommand (Core Logic)
+    description: "Implement the non-interactive parts of the `next` subcommand: loading the plan, finding the next task/steps, and preparing data for prompt generation."
+    files:
+      - src/rmplan/rmplan.ts
+      - src/rmplan/planSchema.ts
+    steps:
+      - prompt: |
+          Define arguments for the `next` subcommand in `src/rmplan/rmplan.ts`.
+          1.  Target the `.command('next')` definition.
+          2.  Add a required argument `<planFile>` for the path to the plan YAML file.
+          3.  Update the `.action()` function to accept `planFile`.
+      - prompt: |
+          Implement plan loading, parsing, validation, and finding the next active task.
+          1.  Inside the `next` action, load, parse, and validate the `planFile` similarly to the `done` command. Store valid data in `planData`.
+          2.  Initialize `activeTask = null`, `activeTaskIndex = -1`.
+          3.  Iterate through `planData.tasks` with index `i`.
+          4.  For each task, check if *any* step within `task.steps` has `done === false` using `task.steps.some(step => !step.done)`.
+          5.  If such a task is found, assign it to `activeTask`, store its index `i` in `activeTaskIndex`, and `break` the loop.
+          6.  If after the loop `activeTask` is still `null`, print "No pending steps found in the plan." and exit.
+      - prompt: |
+          Identify completed and pending steps within the active task.
+          1.  Assuming `activeTask` is found:
+          2.  Create two arrays: `completedSteps` and `pendingSteps`.
+          3.  Iterate through `activeTask.steps`.
+          4.  If `step.done` is true, add it to `completedSteps`.
+          5.  If `step.done` is false, add it to `pendingSteps`.
+      - prompt: |
+          Add tests for the `next` subcommand's core logic.
+          1.  In `src/rmplan/rmplan.test.ts`, add tests for `next`.
+          2.  Test loading, parsing, validation.
+          3.  Test finding the correct next task with pending steps.
+          4.  Test correctly identifying `completedSteps` and `pendingSteps`.
+          5.  Test the scenario where all tasks/steps are already completed.
+
+  - title: Implement `next` Subcommand (Interaction and `rmfilter` Call)
+    description: Add user interaction to select steps and implement the final prompt generation and call to `rmfilter`.
+    files:
+      - src/rmplan/rmplan.ts
+      - package.json
+    steps:
+      - prompt: |
+          Add user interaction to select pending steps.
+          1.  Add `inquirer` as a dependency: `bun add inquirer @types/inquirer`.
+          2.  Import `inquirer` in `src/rmplan/rmplan.ts`.
+          3.  Inside the `next` action, after identifying `pendingSteps`:
+          4.  If `pendingSteps.length === 0`, print "No pending steps in the current task." and exit (this shouldn't happen if the task was selected correctly, but good practice).
+          5.  Use `inquirer.prompt` with a `checkbox` type question:
+              ```typescript
+              const answers = await inquirer.prompt([
+                {
+                  type: 'checkbox',
+                  name: 'selectedSteps',
+                  message: 'Select steps to include in the prompt for the next action:',
+                  choices: pendingSteps.map((step, index) => ({
+                    name: \`[\${index + 1}] \${step.prompt.split('\\n')[0]}...\`, // Display step index and first line
+                    value: step, // Store the whole step object
+                    checked: index === 0, // Pre-select the first pending step by default
+                  })),
+                  validate: (input) => input.length > 0 ? true : 'Please select at least one step.',
+                },
+              ]);
+              const selectedPendingSteps = answers.selectedSteps; // Array of selected step objects
+              ```
+          6.  Store the result in `selectedPendingSteps`.
+      - prompt: |
+          Construct the final prompt for the LLM.
+          1.  Create a prompt string builder or array.
+          2.  Add the overall plan context: `Goal: ${planData.goal}\nDetails: ${planData.details}\n`.
+          3.  Add the current task context: `Current Task: ${activeTask.title}\nDescription: ${activeTask.description}\n`.
+          4.  Add completed steps summary (optional, could be just the count or first lines):
+              ```typescript
+              if (completedSteps.length > 0) {
+                promptParts.push('Completed Steps in this Task:');
+                completedSteps.forEach((step, index) => promptParts.push(`- [DONE] ${step.prompt.split('\\n')[0]}...`));
+              }
+              ```
+          5.  Add the selected pending steps:
+              ```typescript
+              promptParts.push('\nSelected Next Steps to Implement:');
+              selectedPendingSteps.forEach((step, index) => promptParts.push(`- [TODO ${index + 1}] ${step.prompt}`));
+              ```
+          6.  Join the prompt parts into a single string `llmPrompt`.
+      - prompt: |
+          Implement temporary file handling and the call to `rmfilter` for the `next` subcommand.
+          1.  Write the generated `llmPrompt` to a temporary file (similar to the `generate` command). Use try/finally for cleanup.
+          2.  Get the list of files for the current task: `const taskFiles = activeTask.files;`.
+          3.  Construct the argument list for `rmfilter`: `['rmfilter', ...taskFiles, '--bare', '--instructions', \`@\${tempFilePath}\`]`.
+          4.  Execute `rmfilter` using `logSpawn` with inherited stdio.
+          5.  Await completion and check the exit code.
+          6.  Clean up the temporary file in the `finally` block.
+      - prompt: |
+          Add tests for the `next` subcommand's interaction and `rmfilter` call.
+          1.  In `src/rmplan/rmplan.test.ts`:
+          2.  Mock `inquirer.prompt` to simulate user selecting specific steps.
+          3.  Verify that the generated LLM prompt string contains the correct goal, details, task info, completed steps summary, and *only* the selected pending steps.
+          4.  Mock `Bun.write` and `Bun.file().unlink()` for temp file checks.
+          5.  Mock `logSpawn` and assert that `rmfilter` is called with the correct arguments: the task's files, `--bare`, and `--instructions @<tempfile>`.
+

--- a/tasks/0002-rmplan.yml
+++ b/tasks/0002-rmplan.yml
@@ -83,6 +83,7 @@ tasks:
           3.  Import `os` and `path`.
           4.  Generate a unique temporary file path, e.g., `path.join(os.tmpdir(), \`rmplan-prompt-\${Date.now()}.md\`)`.
           5.  Write the generated planning prompt string to this temporary file using `Bun.write()`. Use a try/finally block to ensure cleanup.
+        done: true
       - prompt: |
           Implement the logic to call `rmfilter`.
           1.  Import `logSpawn` from `src/rmfilter/utils.ts`.
@@ -92,6 +93,7 @@ tasks:
           5.  Use `logSpawn` to execute the `rmfilter` command. Ensure `stdio` is configured appropriately (likely `'inherit'` for `stdout`, `stderr`, `stdin`) so `rmfilter` interacts directly with the user's terminal or pipes.
           6.  Await the completion of the `rmfilter` process using `await proc.exited`. Check the exit code for errors.
           7.  Inside the `finally` block from the previous step, delete the temporary file using `Bun.file(tempFilePath).unlink()`.
+        done: true
       - prompt: |
           Add tests for the `generate` subcommand.
           1.  In `src/rmplan/rmplan.test.ts`, add tests specifically for `generate`.

--- a/tasks/0002-rmplan.yml
+++ b/tasks/0002-rmplan.yml
@@ -142,6 +142,7 @@ tasks:
           2.  Check if the `options.output` file path was provided.
           3.  If yes, write the stringified YAML to `options.output` using `Bun.write()`.
           4.  If no, print the stringified YAML to stdout using `console.log()`.
+        done: true
       - prompt: |
           Add tests for the `extract` subcommand.
           1.  In `src/rmplan/rmplan.test.ts`, add tests for `extract`.

--- a/tasks/0002-rmplan.yml
+++ b/tasks/0002-rmplan.yml
@@ -44,10 +44,12 @@ tasks:
           2.  Add an entry for `rmplan`: `"rmplan": "src/rmplan/rmplan.ts"`.
           3.  Run `bun install` to link the binary.
           4.  Verify you can run `rmplan --help` and see the basic structure and subcommands.
+        done: true
       - prompt: |
           Add basic integration tests for the CLI structure.
           1.  Create a test file, e.g., `src/rmplan/rmplan.test.ts`.
           2.  Add tests that execute `rmplan --help`, `rmplan generate --help`, etc. (using `Bun.spawnSync` or similar) and assert that the command runs without error and prints help output. This verifies the basic `commander` setup.
+        done: true
 
   - title: Implement `generate` Subcommand
     description: Implement the logic for the `generate` subcommand, including argument handling, prompt generation, temporary file usage, and calling `rmfilter`.
@@ -63,6 +65,7 @@ tasks:
           2.  Add options `--plan <file>` and `--plan-editor`. Use `.option()` for these. Make them conflict (a user should provide one or the other, or maybe neither if we allow piping later, but let's require one for now). You might need custom logic for this check later.
           3.  Allow arbitrary arguments after `--` to be passed to `rmfilter`. Commander can handle this using `.allowUnknownOption().parseOptions(process.argv)`. You'll need to manually find the index of `--` and slice the args.
           4.  Update the `.action()` function for `generate` to accept `options` and `command` (which contains the arguments).
+        done: true
       - prompt: |
           Implement the plan loading logic for the `generate` subcommand.
           1.  Inside the `generate` action, check if `--plan` or `--plan-editor` was provided. Exit with an error if neither is present.
@@ -72,6 +75,7 @@ tasks:
               - Call `await getInstructionsFromEditor('rmplan-plan.md')` (use a specific filename) to get the plan text from the user's editor.
               - Handle potential errors (e.g., empty input).
           4.  Store the loaded plan text in a variable `planText`.
+        done: true
       - prompt: |
           Implement the prompt generation and temporary file handling.
           1.  Import `planPrompt` from `src/rmplan/prompt.ts`.

--- a/tasks/0002-rmplan.yml
+++ b/tasks/0002-rmplan.yml
@@ -167,6 +167,7 @@ tasks:
           2.  Add a required argument `<planFile>` for the path to the plan YAML file.
           3.  Add a boolean option `--task` using `.option('--task', 'Mark all steps in the current task as done')`.
           4.  Update the `.action()` function to accept `planFile` and `options`.
+        done: true
       - prompt: |
           Implement file loading, parsing, and validation for the `done` subcommand.
           1.  Import `yaml`.
@@ -174,6 +175,7 @@ tasks:
           3.  Inside the `done` action, read the content of `planFile` using `Bun.file(planFile).text()`.
           4.  Parse the content using `yaml.parse()`.
           5.  Validate the parsed object using `planSchema.safeParse()`. Handle errors (print to stderr, exit). Store the valid data in `planData`.
+        done: true
       - prompt: |
           Implement the logic to find and mark the next step/task as done.
           1.  Initialize variables `foundTaskIndex = -1`, `foundStepIndex = -1`.
@@ -188,11 +190,13 @@ tasks:
               - Iterate through all steps in `planData.tasks[foundTaskIndex].steps` and set `step.done = true` for each.
           10. Else (`options.task` is false):
               - Set `planData.tasks[foundTaskIndex].steps[foundStepIndex].done = true`.
+        done: true
       - prompt: |
           Implement saving the modified plan back to the file.
           1.  Stringify the modified `planData` object back into YAML using `yaml.stringify()`.
           2.  Write the updated YAML string back to the original `planFile` path using `Bun.write()`.
           3.  Optionally print a confirmation message like "Marked step X in task Y as done." or "Marked task Y as done.".
+        done: true
       - prompt: |
           Add tests for the `done` subcommand.
           1.  In `src/rmplan/rmplan.test.ts`, add tests for `done`.


### PR DESCRIPTION
This is a new utility called rmplan, which is used for generating plans for a given task and then executing that plan.

## Commands

### Generate
 
The `generate` command generates a planning prompt and context for a given task by inserting the plan into the planning prompt at rmfind/prompt.ts,
and then calling rmfilter to generate the context. It should support --plan and --plan-editor arguments, similar to the rmfilter
command's --instruction and --instruction-editor arguments.

Once the planning prompt is created, take all the other arguments after the first `--` in the command line and pass them
to the rmfilter command, along with the `--bare` flag and the relevant `--instructions @tempfile.md` argument to include the planning
prompt. You can save the planning prompt to a temporary file.

### Extract

The `extract` command takes a response from the language model which should contain a YAML file that complies with the
`planSchema`. The response may include other text so it should find the relevant portion to parse. Then output to stdout
or write it to a file if the `-o` argument is provided.

### Done

The `done` command takes a YAML file as an argument that complies with `planSchema`. Find the next unfinished step and mark it as done.
If the --task argument is provided, find the next unfinished step and mark all the steps in that task as done.

### Next

The `next` command takes a YAML file as an argument that complies with `planSchema`. 

1. Find the next unfinished task to work on.
2. Look at all the unfinished steps in that task.
3. Show the unfinished steps, and allow the user to choose up to which step should go into the prompt. 
4. Output the combined prompt with the files, steps and other relevant information from the task and top-level context. Include
   a bit of information about previous steps that were done.
