### PR TITLE
Add import analysis to rmplan

### DIFF
--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -381,9 +381,12 @@ program
       });
 
       const llmPrompt = promptParts.join('\n');
-      console.log('\n----- LLM PROMPT -----\n');
-      console.log(llmPrompt);
-      console.log('\n---------------------\n');
+      if (!options.rmfilter) {
+        // rmfilter will print the prompt if we are using it, but print it out otherwise
+        console.log('\n----- LLM PROMPT -----\n');
+        console.log(llmPrompt);
+        console.log('\n---------------------\n');
+      }
 
       // Step 1: Write llmPrompt to a temporary file
       const tmpPromptPath = path.join(os.tmpdir(), `rmplan-next-prompt-${Date.now()}.md`);

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -445,11 +445,6 @@ program
             candidateFilesForImports,
             options.withAllImports
           );
-          console.log({
-            files,
-            expandedFiles,
-            candidateFilesForImports,
-          });
           const combinedFiles = [...files, ...expandedFiles];
           const uniqueFiles = Array.from(new Set(combinedFiles));
           files = uniqueFiles;

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -451,7 +451,9 @@ program
 
       // Build the LLM prompt
       const promptParts: string[] = [];
-      promptParts.push(`# Goal: ${planData.goal}\n\nDetails: ${planData.details}\n`);
+      promptParts.push(
+        `# Project Goal: ${planData.goal}\n\n## Project Details:\n\n${planData.details}\n`
+      );
       promptParts.push(
         `## Current Task: ${activeTask.title}\n\nDescription: ${activeTask.description}\n`
       );
@@ -474,7 +476,7 @@ program
 
       promptParts.push('\n## Selected Next Subtasks to Implement:\n');
       selectedPendingSteps.forEach((step, index) => {
-        promptParts.push(`- [TODO ${index + 1}] ${step.prompt}`);
+        promptParts.push(`- [${index + 1}] ${step.prompt}`);
       });
 
       const llmPrompt = promptParts.join('\n');

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -424,10 +424,6 @@ program
                     await walker.getImportTree(filePath, results);
                   } else {
                     const definingFiles = await walker.getDefiningFiles(filePath);
-                    console.log({
-                      filePath,
-                      definingFiles,
-                    });
                     definingFiles.forEach((imp) => results.add(imp));
                     results.add(filePath);
                   }

--- a/src/rmplan/rmplan.ts
+++ b/src/rmplan/rmplan.ts
@@ -372,6 +372,7 @@ program
 
       const selectedPendingSteps = pendingSteps.slice(0, selectedIndex + 1);
 
+      let candidateFilesForImports: string[] = [];
       if (performImportAnalysis) {
         const prompts = selectedPendingSteps.map((step) => step.prompt).join('\n');
         const gitRoot = await getGitRoot();
@@ -381,7 +382,6 @@ program
         );
         const resolvedTaskFiles = files; // Reuse existing resolved files
 
-        let candidateFilesForImports: string[] = [];
         if (filesFromPrompt.length > 0) {
           // If prompt has files, use them. Assume they are absolute or resolvable from gitRoot.
           // Ensure they are absolute paths.

--- a/tasks/0003-rmplan-imports.yml
+++ b/tasks/0003-rmplan-imports.yml
@@ -67,7 +67,7 @@ tasks:
                ```
           Ensure the new options are documented in the command's help text
           implicitly by commander.
-        done: false
+        done: true
   - title: Implement Candidate File Extraction
     description: Implement the logic to determine the initial set of files for
       import analysis, using either files mentioned in the prompt or the task's

--- a/tasks/0003-rmplan-imports.yml
+++ b/tasks/0003-rmplan-imports.yml
@@ -253,7 +253,7 @@ tasks:
           Ensure all file paths used within this block
           (`candidateFilesForImports`, results from `ImportWalker`, the final
           `files` list) are absolute paths.
-        done: false
+        done: true
   - title: Refine and Test
     description: Review path handling, add logging, and perform manual testing of
       all scenarios.

--- a/tasks/0003-rmplan-imports.yml
+++ b/tasks/0003-rmplan-imports.yml
@@ -289,4 +289,4 @@ tasks:
           variables. Ensure error handling (e.g., file not found during
           standalone analysis) is reasonable (e.g., prints a warning and
           continues).
-        done: false
+        done: true

--- a/tasks/0003-rmplan-imports.yml
+++ b/tasks/0003-rmplan-imports.yml
@@ -174,7 +174,7 @@ tasks:
               ```
           Adjust the existing `rmfilterArgs` construction carefully to achieve
           this conditional inclusion.
-        done: false
+        done: true
   - title: Implement Standalone Import Analysis
     description: Implement the import analysis directly within rmplan for cases
       where `--rmfilter` is not used, leveraging the existing `ImportWalker` and

--- a/tasks/0003-rmplan-imports.yml
+++ b/tasks/0003-rmplan-imports.yml
@@ -115,7 +115,7 @@ tasks:
           Make sure `candidateFilesForImports` holds absolute paths at the end
           of this step. Log the source and count of candidate files if not
           quiet.
-        done: false
+        done: true
   - title: Implement --rmfilter Integration
     description: Modify the rmfilter execution logic to pass the candidate files and
       import flags correctly when both `--rmfilter` and an import option are


### PR DESCRIPTION
Add options to rmplan which work like the --with-imports and --with-all-imports options for rmfilter.

When running rmplan with these options, the list of candidate files for import analysis should be the filenames in the prompt itself.
Use the `extractFileReferencesFromInstructions` function to find these files. If no files are found, then use the task's
list of files instead.

If running with the --rmfilter option, then these files can be passed in a command block to rmfilter with the relevant
imports option.

If not running with the --rmfilter option, then run the same import analysis that rmfilter does, and add the resulting
list of files to the task `files` list before generating the output. Make sure to dedupe the files list in that case.



