### PR TITLE
Fix answer-pr to check for uncommitted changes before committing

### DIFF
--- a/src/rmfilter/utils.test.ts
+++ b/src/rmfilter/utils.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import * as path from 'node:path';
-import { validatePath } from './utils';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import { validatePath, hasUncommittedChanges, logSpawn } from './utils';
 import { parseCliArgsFromString } from './utils';
 
 describe('validatePath', () => {
@@ -133,5 +135,73 @@ describe('parseCliArgsFromString', () => {
     const input = 'arg1   arg2  "arg 3"';
     const expected = ['arg1', 'arg2', 'arg 3'];
     expect(parseCliArgsFromString(input)).toEqual(expected);
+  });
+});
+
+describe('hasUncommittedChanges', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'test-git-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('should return false for a clean git repository', async () => {
+    // Initialize a git repo
+    await logSpawn(['git', 'init'], { cwd: tempDir }).exited;
+    await logSpawn(['git', 'config', 'user.email', 'test@example.com'], { cwd: tempDir }).exited;
+    await logSpawn(['git', 'config', 'user.name', 'Test User'], { cwd: tempDir }).exited;
+
+    // Create a file and commit it
+    const testFile = path.join(tempDir, 'test.txt');
+    await fs.writeFile(testFile, 'initial content');
+    await logSpawn(['git', 'add', '.'], { cwd: tempDir }).exited;
+    await logSpawn(['git', 'commit', '-m', 'Initial commit'], { cwd: tempDir }).exited;
+
+    const hasChanges = await hasUncommittedChanges(tempDir);
+    expect(hasChanges).toBe(false);
+  });
+
+  it('should return true for uncommitted changes in working directory', async () => {
+    // Initialize a git repo
+    await logSpawn(['git', 'init'], { cwd: tempDir }).exited;
+    await logSpawn(['git', 'config', 'user.email', 'test@example.com'], { cwd: tempDir }).exited;
+    await logSpawn(['git', 'config', 'user.name', 'Test User'], { cwd: tempDir }).exited;
+
+    // Create and commit initial file
+    const testFile = path.join(tempDir, 'test.txt');
+    await fs.writeFile(testFile, 'initial content');
+    await logSpawn(['git', 'add', '.'], { cwd: tempDir }).exited;
+    await logSpawn(['git', 'commit', '-m', 'Initial commit'], { cwd: tempDir }).exited;
+
+    // Make changes without committing
+    await fs.writeFile(testFile, 'modified content');
+
+    const hasChanges = await hasUncommittedChanges(tempDir);
+    expect(hasChanges).toBe(true);
+  });
+
+  it('should return true for staged changes', async () => {
+    // Initialize a git repo
+    await logSpawn(['git', 'init'], { cwd: tempDir }).exited;
+    await logSpawn(['git', 'config', 'user.email', 'test@example.com'], { cwd: tempDir }).exited;
+    await logSpawn(['git', 'config', 'user.name', 'Test User'], { cwd: tempDir }).exited;
+
+    // Create and commit initial file
+    const testFile = path.join(tempDir, 'test.txt');
+    await fs.writeFile(testFile, 'initial content');
+    await logSpawn(['git', 'add', '.'], { cwd: tempDir }).exited;
+    await logSpawn(['git', 'commit', '-m', 'Initial commit'], { cwd: tempDir }).exited;
+
+    // Stage a new file
+    const newFile = path.join(tempDir, 'new.txt');
+    await fs.writeFile(newFile, 'new content');
+    await logSpawn(['git', 'add', newFile], { cwd: tempDir }).exited;
+
+    const hasChanges = await hasUncommittedChanges(tempDir);
+    expect(hasChanges).toBe(true);
   });
 });

--- a/src/rmpr/git_utils.ts
+++ b/src/rmpr/git_utils.ts
@@ -220,7 +220,7 @@ export async function getCurrentBranchName(cwd?: string): Promise<string | null>
 }
 
 /**
- * Gets the SHA of the current commit (HEAD for git, @ for jj).
+ * Gets the SHA of the current commit (HEAD for git, @- for jj).
  * @param cwd The working directory to run the command in. Defaults to process.cwd().
  * @returns A promise that resolves to the commit SHA string if successful, or null if an error occurs.
  */
@@ -236,8 +236,8 @@ export async function getCurrentCommitSha(cwd?: string): Promise<string | null> 
 
   try {
     if (hasJj) {
-      // For jj, get the current commit ID
-      const proc = logSpawn(['jj', 'log', '-r', '@', '--no-graph', '-T', 'commit_id'], {
+      // For jj, get the last commit ID
+      const proc = logSpawn(['jj', 'log', '-r', '@-', '--no-graph', '-T', 'commit_id'], {
         cwd: workingDir,
         stdout: 'pipe',
         stderr: 'pipe',


### PR DESCRIPTION
- Add hasUncommittedChanges function to check git/jj status  
- Modify answer-pr to check for uncommitted changes before committing
- If no changes exist, get current commit SHA instead of creating a new commit
- Add support for jj in getCurrentCommitSha function
- Add tests for hasUncommittedChanges function

This prevents answer-pr from trying to create an empty commit when the executor has already committed the changes.

Closes #89 