### PR TITLE
Rename plan overview prompt tool to load-plan

### DIFF
--- a/src/rmplan/mcp/generate_mode.test.ts
+++ b/src/rmplan/mcp/generate_mode.test.ts
@@ -13,6 +13,7 @@ import {
   handleGenerateTasksTool,
   handleGetPlanTool,
   loadGeneratePrompt,
+  loadPlanPrompt,
   loadQuestionsPrompt,
   loadResearchPrompt,
   type GenerateModeRegistrationContext,
@@ -76,6 +77,14 @@ describe('rmplan MCP generate mode helpers', () => {
     expect(message?.text).toContain('generate a detailed implementation plan');
     expect(message?.text).toContain('update-plan-tasks tool');
     expect(message?.text).toContain('Break the project into phases');
+  });
+
+  test('loadPlanPrompt returns plan details and wait instruction', async () => {
+    const prompt = await loadPlanPrompt({ plan: planPath }, context);
+    const message = prompt.messages[0]?.content;
+    expect(message?.text).toContain('Plan ID: 99999');
+    expect(message?.text).toContain('Test Plan');
+    expect(message?.text).toContain('Wait for your human collaborator');
   });
 
   test('handleAppendResearchTool appends research to the plan file', async () => {

--- a/src/rmplan/mcp/generate_mode.ts
+++ b/src/rmplan/mcp/generate_mode.ts
@@ -147,6 +147,28 @@ export async function loadQuestionsPrompt(
   };
 }
 
+export async function loadPlanPrompt(
+  args: { plan: string },
+  context: GenerateModeRegistrationContext
+) {
+  const { plan, planPath } = await resolvePlan(args.plan, context);
+  const contextBlock = buildPlanContext(plan, planPath, context);
+
+  const text = `${contextBlock}\n\nWait for your human collaborator to review the plan and provide further instructions before taking any additional action.`;
+
+  return {
+    messages: [
+      {
+        role: 'user' as const,
+        content: {
+          type: 'text' as const,
+          text,
+        },
+      },
+    ],
+  };
+}
+
 export async function loadGeneratePrompt(
   args: { plan?: string },
   context: GenerateModeRegistrationContext
@@ -484,6 +506,20 @@ export function registerGenerateMode(
       },
     ],
     load: async (args) => loadQuestionsPrompt({ plan: args.plan }, context),
+  });
+
+  server.addPrompt({
+    name: 'load-plan',
+    description:
+      'Load a plan and share its current details, then wait for the human collaborator before taking additional action.',
+    arguments: [
+      {
+        name: 'plan',
+        description: 'Plan ID or file path to load',
+        required: true,
+      },
+    ],
+    load: async (args) => loadPlanPrompt({ plan: args.plan }, context),
   });
 
   server.addPrompt({


### PR DESCRIPTION
## Summary
- rename the plan overview MCP prompt function to `loadPlanPrompt`
- register the MCP prompt under the `load-plan` name instead of `plan-overview`
- update generate mode tests to cover the renamed prompt

## Testing
- bun test src/rmplan/mcp/generate_mode.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e9d40010288324af5a1618c4fbfe62