### PR TITLE
Add executor-specific autofix options to review command

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "llmutils",
@@ -47,6 +46,7 @@
         "tree-sitter-svelte": "^0.11.0",
         "tree-sitter-typescript": "^0.23.2",
         "web-tree-sitter": "^0.25.10",
+        "which": "^6.0.0",
         "yaml": "^2.8.0",
         "zod": "^3.25.67",
       },
@@ -58,6 +58,7 @@
         "@types/diff": "^8.0.0",
         "@types/js-yaml": "^4.0.9",
         "@types/micromatch": "^4.0.9",
+        "@types/which": "^3.0.4",
         "eslint": "^9.39.2",
         "globals": "^17.0.0",
         "prettier": "^3.7.4",
@@ -264,6 +265,8 @@
     "@types/micromatch": ["@types/micromatch@4.0.10", "", { "dependencies": { "@types/braces": "*" } }, "sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ=="],
 
     "@types/node": ["@types/node@22.13.10", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw=="],
+
+    "@types/which": ["@types/which@3.0.4", "", {}, "sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.51.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.51.0", "@typescript-eslint/type-utils": "8.51.0", "@typescript-eslint/utils": "8.51.0", "@typescript-eslint/visitor-keys": "8.51.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.2.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.51.0", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-XtssGWJvypyM2ytBnSnKtHYOGT+4ZwTnBVl36TA4nRO2f4PRNGz5/1OszHzcZCvcBMh+qb7I06uoCmLTRdR9og=="],
 
@@ -581,7 +584,7 @@
 
     "is64bit": ["is64bit@2.0.0", "", { "dependencies": { "system-architecture": "^0.1.0" } }, "sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw=="],
 
-    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+    "isexe": ["isexe@3.1.1", "", {}, "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="],
 
     "jose": ["jose@6.1.3", "", {}, "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ=="],
 
@@ -863,7 +866,7 @@
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+    "which": ["which@6.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -931,6 +934,8 @@
 
     "cliui/wrap-ansi": ["wrap-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q=="],
 
+    "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "eslint/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "eslint/find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
@@ -992,6 +997,8 @@
     "cliui/string-width/emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
 
     "cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "eslint/find-up/locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/diff": "^8.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/micromatch": "^4.0.9",
+    "@types/which": "^3.0.4",
     "eslint": "^9.39.2",
     "globals": "^17.0.0",
     "prettier": "^3.7.4",
@@ -80,6 +81,7 @@
     "tree-sitter-svelte": "^0.11.0",
     "tree-sitter-typescript": "^0.23.2",
     "web-tree-sitter": "^0.25.10",
+    "which": "^6.0.0",
     "yaml": "^2.8.0",
     "zod": "^3.25.67"
   },

--- a/src/rmplan/commands/review.ts
+++ b/src/rmplan/commands/review.ts
@@ -45,7 +45,26 @@ import { access, constants } from 'node:fs/promises';
 import { statSync } from 'node:fs';
 import { validateInstructionsFilePath } from '../utils/file_validation.js';
 import { createCleanupPlan, type CleanupPlanOptions } from '../utils/cleanup_plan_creator.js';
-import { prepareReviewExecutors, runReview, type ReviewPromptBuilder } from '../review_runner.js';
+import {
+  prepareReviewExecutors,
+  runReview,
+  type ReviewExecutorName,
+  type ReviewPromptBuilder,
+} from '../review_runner.js';
+import which from 'which';
+const FIX_EXECUTOR_COMMANDS = {
+  'claude-code': 'claude',
+  'codex-cli': 'codex',
+} as const satisfies Record<ReviewExecutorName, string>;
+type FixAction = 'fix-claude' | 'fix-codex';
+const FIX_ACTION_EXECUTOR_MAP: Record<FixAction, ReviewExecutorName> = {
+  'fix-claude': 'claude-code',
+  'fix-codex': 'codex-cli',
+};
+const FIX_ACTION_LABELS: Record<FixAction, string> = {
+  'fix-claude': 'Fix now with Claude (apply fixes immediately)',
+  'fix-codex': 'Fix now with Codex (apply fixes immediately)',
+};
 
 /**
  * Comprehensive error handling for saving review results
@@ -200,6 +219,35 @@ const reviewPrintQuietLogger: LoggerAdapter = {
   writeStderr: () => {},
   debugLog: () => {},
 };
+
+async function isCommandAvailable(command: string): Promise<boolean> {
+  const result = await which(command, { nothrow: true });
+  return Boolean(result);
+}
+
+async function getAvailableFixActions(): Promise<
+  Array<{ action: FixAction; executor: ReviewExecutorName; label: string }>
+> {
+  const results = await Promise.all(
+    (Object.entries(FIX_ACTION_EXECUTOR_MAP) as Array<[FixAction, ReviewExecutorName]>).map(
+      async ([action, executor]) => {
+        const command = FIX_EXECUTOR_COMMANDS[executor];
+        const available = await isCommandAvailable(command);
+
+        if (!available) {
+          return null;
+        }
+
+        return { action, executor, label: FIX_ACTION_LABELS[action] };
+      }
+    )
+  );
+
+  return results.filter(
+    (result): result is { action: FixAction; executor: ReviewExecutorName; label: string } =>
+      result !== null
+  );
+}
 
 export async function handleReviewCommand(
   planFile: string | undefined,
@@ -453,6 +501,7 @@ export async function handleReviewCommand(
     if (!reviewExecutorName) {
       throw new Error('Review completed without a usable executor result.');
     }
+    let autofixExecutorName: ReviewExecutorName | null = reviewExecutorName;
 
     // Determine format and verbosity from options or config
     const outputFormat = isPrintMode
@@ -529,13 +578,18 @@ export async function handleReviewCommand(
         }
       } else if (!options.noAutofix) {
         // Prompt user for action when interactive; otherwise skip prompting
-        let action: 'fix' | 'cleanup' | 'append' | 'exit' = 'exit';
+        const availableFixActions = await getAvailableFixActions();
+        type ReviewIssueAction = FixAction | 'cleanup' | 'append' | 'exit';
+        let action: ReviewIssueAction = 'exit';
         if (isInteractiveEnv) {
           action = await select({
             message: 'Issues were found during review. What would you like to do?',
             choices: [
               { name: 'Append issues to the current plan as tasks', value: 'append' },
-              { name: 'Fix now (apply fixes immediately)', value: 'fix' },
+              ...availableFixActions.map((option) => ({
+                name: option.label,
+                value: option.action,
+              })),
               { name: 'Create a cleanup plan (for later execution)', value: 'cleanup' },
               { name: 'Exit (do nothing)', value: 'exit' },
             ],
@@ -545,8 +599,9 @@ export async function handleReviewCommand(
           log(chalk.gray('Non-interactive environment detected; skipping fix/cleanup prompts.'));
         }
 
-        if (action === 'fix') {
+        if (action === 'fix-claude' || action === 'fix-codex') {
           shouldAutofix = true;
+          autofixExecutorName = FIX_ACTION_EXECUTOR_MAP[action];
           if (reviewResult.issues && reviewResult.issues.length > 0) {
             selectedIssues = await selectIssuesToFix(reviewResult.issues, 'fix');
             shouldAutofix = selectedIssues.length > 0;
@@ -763,11 +818,8 @@ export async function handleReviewCommand(
         );
 
         // Execute autofix using the executor in normal mode
-        const autofixExecutor = buildExecutorAndLog(
-          reviewExecutorName,
-          sharedExecutorOptions,
-          config
-        );
+        const executorName = autofixExecutorName ?? reviewExecutorName;
+        const autofixExecutor = buildExecutorAndLog(executorName, sharedExecutorOptions, config);
 
         const autofixOutput = await autofixExecutor.execute(autofixPrompt, {
           planId: planData.id?.toString() ?? 'unknown',

--- a/src/rmplan/executors/claude_code.ts
+++ b/src/rmplan/executors/claude_code.ts
@@ -684,7 +684,9 @@ export class ClaudeCodeExecutor implements Executor {
         initialInactivityTimeoutMs: 2 * 60 * 1000, // 2 minutes to start
         onInactivityKill: () => {
           killedByTimeout = true;
-          log(`Claude review timed out after ${Math.round(reviewTimeoutMs / 60000)} minutes; terminating.`);
+          log(
+            `Claude review timed out after ${Math.round(reviewTimeoutMs / 60000)} minutes; terminating.`
+          );
         },
         formatStdout: (output) => {
           let lines = splitter(output);
@@ -707,7 +709,9 @@ export class ClaudeCodeExecutor implements Executor {
       });
 
       if (killedByTimeout || result.killedByInactivity) {
-        throw new Error(`Claude review timed out after ${Math.round(reviewTimeoutMs / 60000)} minutes`);
+        throw new Error(
+          `Claude review timed out after ${Math.round(reviewTimeoutMs / 60000)} minutes`
+        );
       }
 
       if (result.exitCode !== 0) {

--- a/src/rmplan/review_runner.ts
+++ b/src/rmplan/review_runner.ts
@@ -122,8 +122,7 @@ async function executeWithRetry(
   prepared: PreparedReviewExecutor,
   planInfo: ReviewPlanInfo
 ): Promise<
-  | { name: ReviewExecutorName; rawOutput: string }
-  | { name: ReviewExecutorName; error: unknown }
+  { name: ReviewExecutorName; rawOutput: string } | { name: ReviewExecutorName; error: unknown }
 > {
   const maxAttempts = MAX_TIMEOUT_RETRIES + 1;
 
@@ -142,7 +141,9 @@ async function executeWithRetry(
       return { name: prepared.name, rawOutput };
     } catch (error) {
       if (isTimeoutError(error) && attempt < maxAttempts) {
-        log(`${prepared.name} review timed out, retrying (attempt ${attempt + 1}/${maxAttempts})...`);
+        log(
+          `${prepared.name} review timed out, retrying (attempt ${attempt + 1}/${maxAttempts})...`
+        );
         continue;
       }
       return { name: prepared.name, error };


### PR DESCRIPTION
## Summary
- offer separate "fix with Claude" and "fix with Codex" options in the review command, filtering choices based on installed CLIs
- use detected executor selection when launching autofix and add command availability checks via the `which` package
- update formatting where needed and add type definitions for the new dependency

## Testing
- bun run check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ca78fbdd483249e9cbaf3943c0228)