### PR TITLE
tim review: add --previous-response to include prior review output and thread fixer output into Codex reruns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1947,6 +1947,7 @@ tim cleanup [FILES...] [--diff-from BRANCH]
 
 # Review plan changes
 tim review [PLAN] [--executor NAME] [--serial-both] [--task-index N...]
+tim review [PLAN] --previous-response .rmfilter/reviews/last-review.md
 
 # Answer PR comments
 tim answer-pr [PR] [--mode MODE] [--commit] [--comment]

--- a/src/tim/commands/review.test.ts
+++ b/src/tim/commands/review.test.ts
@@ -418,6 +418,47 @@ index 1234567..abcdefg 100644
     expect(prompt).toContain('REVIEWER AGENT');
   });
 
+  test('includes previous review response when provided', async () => {
+    const planData: PlanSchema = {
+      id: 7,
+      title: 'Previous Review Response Test',
+      goal: 'Ensure previous review response is included',
+      tasks: [],
+    };
+
+    const diffResult = {
+      hasChanges: true,
+      changedFiles: ['src/example.ts'],
+      baseBranch: 'main',
+      diffContent: 'diff --git a/src/example.ts b/src/example.ts',
+    };
+
+    await moduleMocker.mock('../executors/claude_code/agent_prompts.js', () => ({
+      getReviewerPrompt: (contextContent: string) => ({
+        name: 'reviewer',
+        description: 'Reviews code',
+        prompt: contextContent,
+      }),
+    }));
+
+    const prompt = buildReviewPrompt(
+      planData,
+      diffResult,
+      false,
+      false,
+      [],
+      [],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'Resolved the missing edge cases in the last review.'
+    );
+
+    expect(prompt).toContain('Previous Review Response');
+    expect(prompt).toContain('Resolved the missing edge cases in the last review.');
+  });
+
   test('includes review scope note when provided', async () => {
     const planData: PlanSchema = {
       id: 7,

--- a/src/tim/executors/codex_cli.fix_loop.test.ts
+++ b/src/tim/executors/codex_cli.fix_loop.test.ts
@@ -178,6 +178,11 @@ describe('CodexCliExecutor - Fix Loop', () => {
     // Third call should be fixer
     expect(calls[2]).toContain('Fixer');
     expect(runExternalReviewForCodexMock).toHaveBeenCalled();
+    expect(runExternalReviewForCodexMock).toHaveBeenCalledTimes(2);
+    const firstCallOptions = runExternalReviewForCodexMock.mock.calls[0]?.[0];
+    const secondCallOptions = runExternalReviewForCodexMock.mock.calls[1]?.[0];
+    expect(firstCallOptions?.previousResponse).toBeUndefined();
+    expect(secondCallOptions?.previousResponse).toBe('Applied targeted fixes.');
     for (const [callOptions] of runExternalReviewForCodexMock.mock.calls) {
       expect(callOptions.executorSelection).toBe('claude-code');
     }

--- a/src/tim/executors/codex_cli/external_review.ts
+++ b/src/tim/executors/codex_cli/external_review.ts
@@ -34,6 +34,7 @@ export interface ExternalReviewOptions {
   implementerOutput: string;
   testerOutput?: string;
   executorSelection?: string;
+  previousResponse?: string;
 }
 
 export interface ExternalReviewResult {
@@ -128,7 +129,9 @@ export async function runExternalReviewForCodex(
       completedChildren,
       customInstructions,
       taskScopeNote,
-      executionContext
+      executionContext,
+      undefined,
+      options.previousResponse
     );
 
   const planInfo = buildPlanInfoForReview(

--- a/src/tim/executors/codex_cli/normal_mode.ts
+++ b/src/tim/executors/codex_cli/normal_mode.ts
@@ -402,6 +402,7 @@ export async function executeNormalMode(
           initiallyPendingTitles,
           implementerOutput: finalImplementerOutput,
           testerOutput,
+          previousResponse: fixerOutput,
           executorSelection: reviewExecutor,
         });
       } catch (error) {

--- a/src/tim/executors/codex_cli/simple_mode.ts
+++ b/src/tim/executors/codex_cli/simple_mode.ts
@@ -339,6 +339,7 @@ export async function executeSimpleMode(
           initiallyCompletedTitles,
           initiallyPendingTitles,
           implementerOutput: finalImplementerOutput,
+          previousResponse: fixerOutput,
           executorSelection: reviewExecutor,
         });
       } catch (error) {

--- a/src/tim/tim.ts
+++ b/src/tim/tim.ts
@@ -913,6 +913,10 @@ program
     'Path to file containing custom review instructions. Overrides config file instructions.'
   )
   .option(
+    '--previous-response <path>',
+    'Path to a file containing the previous review response to include in this review prompt.'
+  )
+  .option(
     '--focus <areas>',
     'Comma-separated list of focus areas (e.g., security,performance,testing). Overrides config focus areas.'
   )


### PR DESCRIPTION
### Motivation

- Provide a way to include the previous review/fixer agent output in subsequent reviews so the reviewer sees what was returned previously. 
- Ensure that when the Codex fixer runs and the reviewer is re-invoked, the fixer’s final output is threaded into the reviewer prompt so the reviewer has the latest fix context.

### Description

- Added a new CLI option `--previous-response <path>` to the `tim review` command in `src/tim/tim.ts` and documented the usage in `README.md`.
- Load and validate the provided file in `handleReviewCommand` and `buildReviewPromptFromOptions` using `validateInstructionsFilePath` and `readFile`, capturing the content as `previousReviewResponse`.
- Extended `buildReviewPrompt` signature to accept a `previousReviewResponse` parameter and include a `# Previous Review Response` section in the generated prompt when present.
- Thread `previousResponse` through the review runner path by adding the field to `ExternalReviewOptions` and passing it into `buildReviewPrompt` in `src/tim/executors/codex_cli/external_review.ts`.
- When running fix loops, pass the fixer agent’s final output as `previousResponse` into subsequent Codex review invocations in `normal_mode.ts` and `simple_mode.ts` so follow-up reviews include the fixer output.
- Tests and small coverage additions: added a unit test to assert the prompt contains the previous response in `src/tim/commands/review.test.ts` and updated the fix-loop test in `src/tim/executors/codex_cli.fix_loop.test.ts` to assert the `previousResponse` is propagated.

### Testing

- Ran code formatting with `bun run format` (completed).
- Ran the test suite with `bun test`; many tests passed but the run reported failures overall: failing cases included `src/rmfilter/additional_docs.test.ts` (expectation diffs for paths) and multiple `src/logging/tunnel_integration.test.ts` assertions/timeouts; these failures appear unrelated to the new `--previous-response` logic and reflect existing brittle expectations in those suites.
- No new runtime or integration regressions were observed for the review prompt generation and the Codex fix-loop propagation in the unit tests that were added/updated (the new assertions exercise the added behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987c71a0ec88324923ab9676411e0d8)