### PR TITLE
Allow orchestrator to apply tiny review follow-ups without spawning implementer

### DIFF
--- a/src/tim/executors/claude_code/orchestrator_prompt.test.ts
+++ b/src/tim/executors/claude_code/orchestrator_prompt.test.ts
@@ -38,10 +38,12 @@ describe('orchestrator_prompt failure protocol', () => {
     expect(out).toContain('tim review 123 --print --executor codex-cli');
   });
 
-
   it('allows small review follow-ups without re-running implementer/reviewer', () => {
     const out = wrapWithOrchestration('Context', '123', { batchMode: false });
-    expect(out).toContain('you may apply the changes yourself without spawning the implementer subagent');
+    expect(out).toContain(
+      'you may apply the changes yourself without spawning the implementer subagent'
+    );
+    expect(out).toContain('small logic adjustments');
     expect(out).toContain('you may skip re-running `tim review 123 --print`');
   });
 
@@ -276,6 +278,7 @@ describe('orchestrator_prompt subagent commands', () => {
       expect(out).toContain(
         'you may apply the changes yourself without spawning the implementer subagent'
       );
+      expect(out).toContain('small logic adjustments');
       expect(out).toContain('you may skip re-running `tim review 71 --print`');
     });
 

--- a/src/tim/executors/claude_code/orchestrator_prompt.ts
+++ b/src/tim/executors/claude_code/orchestrator_prompt.ts
@@ -251,9 +251,9 @@ ${reviewExecutorGuidance}
 ${options.batchMode ? '6' : '5'}. **Iteration**
 
 - If the review output identifies issues or tests fail:
-- For small, low-risk review follow-ups (for example wording tweaks, tiny refactors, or single-line fixes), you may apply the changes yourself without spawning the implementer subagent.
+- For straightforward review follow-ups that are easy to implement correctly (for example wording tweaks, focused refactors, small logic adjustments, or similarly contained edits), you may apply the changes yourself without spawning the implementer subagent.
 - Return to step ${options.batchMode ? '2' : '1'} when substantial code changes are required.
-- After small follow-up changes, run the relevant targeted checks yourself. If all changes are small and verification is straightforward, you may skip re-running \`${reviewCommand}\`.
+- After these straightforward follow-up changes, run the relevant targeted checks yourself. If the entire set of changes is straightforward to verify, you may skip re-running \`${reviewCommand}\`.
 - If the review still flags an issue that was supposedly just fixed, trust the review — the fix was incomplete or incorrect. Investigate the issue again rather than dismissing the feedback.
 - Continue this loop until all tests pass and the implementation is satisfactory`;
 
@@ -295,8 +295,8 @@ function buildImportantGuidelines(planId: string, options: OrchestrationOptions)
 - **DO NOT implement code directly**. Always delegate implementation tasks to the appropriate subagent via \`tim subagent\`.
 - **DO NOT write tests directly**. Always use the tester subagent via \`tim subagent tester\` for test execution and updates.
 - **DO NOT review code directly**. Always run \`${reviewCommand}\` for code quality assessment.
-- Exception: if review feedback requires only tiny, low-risk edits, you may apply those edits directly instead of spawning implementer again.
-- After tiny review follow-ups, run focused verification yourself. If the scope is small and verification is clear, you may skip re-running \`${reviewCommand}\`.
+- Exception: if review feedback requires only straightforward, contained edits, you may apply those edits directly instead of spawning implementer again.
+- After straightforward review follow-ups, run focused verification yourself. If the scope remains straightforward and verification is clear, you may skip re-running \`${reviewCommand}\`.
 - You are responsible only for coordination and ensuring the workflow is followed correctly.
 - The subagents have access to the same task instructions below that you do, so you don't need to repeat them. You should reference which specific task titles are being worked on so the subagents can focus on the right tasks.
 - When invoking subagents, provide clear, specific instructions in \`--input\` (or \`--input-file\`) about what needs to be done in addition to referencing the task titles.
@@ -656,8 +656,8 @@ ${reviewExecutorGuidance}
   const reviewIterationGuidance = isSimpleTdd
     ? ''
     : `
-- For small, low-risk review follow-ups (for example wording tweaks, tiny refactors, or single-line fixes), you may apply the changes yourself without spawning the implementer subagent.
-- After small follow-up changes, run relevant targeted checks yourself. If all changes are small and verification is straightforward, you may skip re-running \`${reviewCommand}\`.`;
+- For straightforward review follow-ups that are easy to implement correctly (for example wording tweaks, focused refactors, small logic adjustments, or similarly contained edits), you may apply the changes yourself without spawning the implementer subagent.
+- After these straightforward follow-up changes, run relevant targeted checks yourself. If the full set of changes is straightforward to verify, you may skip re-running \`${reviewCommand}\`.`;
 
   const workflowInstructions = `## Workflow Instructions
 
@@ -715,8 +715,8 @@ ${iterationPhaseNumber}. **Iteration**
   const reviewFollowupGuidance = isSimpleTdd
     ? ''
     : `
-- Exception: if review feedback requires only tiny, low-risk edits, you may apply those edits directly instead of spawning implementer again.
-- After tiny review follow-ups, run focused verification yourself. If the scope is small and verification is clear, you may skip re-running \`${reviewCommand}\`.`;
+- Exception: if review feedback requires only straightforward, contained edits, you may apply those edits directly instead of spawning implementer again.
+- After straightforward review follow-ups, run focused verification yourself. If the scope remains straightforward and verification is clear, you may skip re-running \`${reviewCommand}\`.`;
 
   const guidance = `## Important Guidelines
 


### PR DESCRIPTION
### Motivation

- Reduce unnecessary subagent invocations by letting the orchestrator handle very small, low-risk review follow-ups itself. 
- Make the loop more efficient when fixes are trivial and easy to verify, avoiding extra latency and resource use.

### Description

- Updated the orchestrator prompt text in `src/tim/executors/claude_code/orchestrator_prompt.ts` to permit the orchestrator to apply small, low-risk review follow-ups (e.g., wording tweaks, tiny refactors, single-line fixes) without running the `implementer` subagent. 
- Added guidance that after such small follow-ups the orchestrator should run focused/targeted checks itself and may skip re-running the reviewer (`tim review`) when verification is straightforward. 
- Applied equivalent guidance to the TDD orchestration flow and consolidated iteration/guidance blocks accordingly. 
- Updated prompt tests in `src/tim/executors/claude_code/orchestrator_prompt.test.ts` to validate the new wording and to align output-file naming expectations to the current prompt text (patterns like `tim-<plan>-...`).

### Testing

- Ran `bun test src/tim/executors/claude_code/orchestrator_prompt.test.ts` and the tests passed. 
- Ran `bun run check` which failed due to an existing, unrelated TypeScript error in `src/common/terminal.ts` (`TS2345`), so type-checking was not fully green in this run. 
- Source files were formatted using the repository formatter prior to finalizing the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a660e4d91c832492a1e69798e05dfe)