### PR TITLE
Allow `tim generate` to run in locked primary workspace

### DIFF
--- a/src/tim/commands/generate.test.ts
+++ b/src/tim/commands/generate.test.ts
@@ -320,6 +320,7 @@ describe('handleGenerateCommand', () => {
       nonInteractive: true,
       requireWorkspace: true,
       planUuid: '11111111-1111-4111-8111-111111111111',
+      allowPrimaryWorkspaceWhenLocked: true,
     });
   });
 

--- a/src/tim/commands/generate.ts
+++ b/src/tim/commands/generate.ts
@@ -203,6 +203,7 @@ export async function handleGenerateCommand(
         requireWorkspace: options.requireWorkspace,
         planUuid: parsedPlan.uuid,
         base: options.base,
+        allowPrimaryWorkspaceWhenLocked: true,
       },
       currentBaseDir,
       currentPlanFile,

--- a/src/tim/workspace/workspace_lock.ts
+++ b/src/tim/workspace/workspace_lock.ts
@@ -14,6 +14,16 @@ import { getWorkspaceByPath, recordWorkspace } from '../db/workspace.js';
 
 export type LockType = 'persistent' | 'pid';
 
+export class WorkspaceAlreadyLocked extends Error {
+  constructor(
+    public readonly workspacePath: string,
+    public readonly lockType: LockType
+  ) {
+    super(`Workspace at ${workspacePath} is already locked (${lockType})`);
+    this.name = 'WorkspaceAlreadyLocked';
+  }
+}
+
 export interface LockInfo {
   type: LockType;
   pid?: number;
@@ -104,14 +114,24 @@ export class WorkspaceLock {
     const lockType: LockType = options.type ?? 'persistent';
     const lockCommand = options.owner ? `${command} (owner: ${options.owner})` : command;
 
-    const created = acquireWorkspaceLock(db, workspaceId, {
-      lockType,
-      pid: this.pid,
-      hostname: os.hostname(),
-      command: lockCommand,
-    });
+    try {
+      const created = acquireWorkspaceLock(db, workspaceId, {
+        lockType,
+        pid: this.pid,
+        hostname: os.hostname(),
+        command: lockCommand,
+      });
+      return this.rowToLockInfo(created);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('already locked')) {
+        const existingLock = this.getExistingLock(workspacePath);
+        if (existingLock) {
+          throw new WorkspaceAlreadyLocked(workspacePath, existingLock.lock.lock_type);
+        }
+      }
 
-    return this.rowToLockInfo(created);
+      throw error;
+    }
   }
 
   static async releaseLock(

--- a/src/tim/workspace/workspace_setup.test.ts
+++ b/src/tim/workspace/workspace_setup.test.ts
@@ -9,7 +9,7 @@ import { recordWorkspace } from '../db/workspace.js';
 import type { TimConfig } from '../configSchema.js';
 import * as git from '../../common/git.js';
 import { WorkspaceAutoSelector } from './workspace_auto_selector.js';
-import { WorkspaceLock } from './workspace_lock.js';
+import { WorkspaceAlreadyLocked, WorkspaceLock } from './workspace_lock.js';
 import * as workspaceCommand from '../commands/workspace.js';
 import * as workspaceManager from './workspace_manager.js';
 import { setupWorkspace } from './workspace_setup.js';
@@ -1178,6 +1178,38 @@ describe('setupWorkspace', () => {
     );
 
     expect(acquireLockSpy).toHaveBeenCalledWith(baseDir, 'tim generate', { type: 'pid' });
+  });
+
+  test('allows generate to continue in primary workspace when already locked and override is enabled', async () => {
+    const acquireLockSpy = spyOn(WorkspaceLock, 'acquireLock').mockRejectedValue(
+      new WorkspaceAlreadyLocked(baseDir, 'pid')
+    );
+
+    const result = await setupWorkspace(
+      { allowPrimaryWorkspaceWhenLocked: true },
+      baseDir,
+      planFile,
+      config,
+      'tim generate'
+    );
+
+    expect(result.baseDir).toBe(baseDir);
+    expect(result.planFile).toBe(planFile);
+    expect(acquireLockSpy).toHaveBeenCalledWith(baseDir, 'tim generate', { type: 'pid' });
+  });
+
+  test('still throws for non-lock errors when primary workspace override is enabled', async () => {
+    spyOn(WorkspaceLock, 'acquireLock').mockRejectedValue(new Error('failed to acquire cwd lock'));
+
+    await expect(
+      setupWorkspace(
+        { allowPrimaryWorkspaceWhenLocked: true },
+        baseDir,
+        planFile,
+        config,
+        'tim generate'
+      )
+    ).rejects.toThrow('failed to acquire cwd lock');
   });
 
   test('locks current working directory when no workspace options are provided', async () => {

--- a/src/tim/workspace/workspace_setup.ts
+++ b/src/tim/workspace/workspace_setup.ts
@@ -9,7 +9,7 @@ import type { TimConfig } from '../configSchema.js';
 import { readPlanFile } from '../plans.js';
 import { WorkspaceAutoSelector } from './workspace_auto_selector.js';
 import { findWorkspaceInfosByTaskId } from './workspace_info.js';
-import { WorkspaceLock } from './workspace_lock.js';
+import { WorkspaceAlreadyLocked, WorkspaceLock } from './workspace_lock.js';
 import {
   createWorkspace,
   prepareExistingWorkspace,
@@ -25,6 +25,7 @@ export interface WorkspaceSetupOptions {
   requireWorkspace?: boolean;
   planUuid?: string;
   base?: string;
+  allowPrimaryWorkspaceWhenLocked?: boolean;
 }
 
 export interface WorkspaceSetupResult {
@@ -298,8 +299,18 @@ export async function setupWorkspace(
     }
   }
 
-  const lockInfo = await WorkspaceLock.acquireLock(baseDir, commandLabel, { type: 'pid' });
-  WorkspaceLock.setupCleanupHandlers(baseDir, lockInfo.type);
+  try {
+    const lockInfo = await WorkspaceLock.acquireLock(baseDir, commandLabel, { type: 'pid' });
+    WorkspaceLock.setupCleanupHandlers(baseDir, lockInfo.type);
+  } catch (err) {
+    if (options.allowPrimaryWorkspaceWhenLocked && err instanceof WorkspaceAlreadyLocked) {
+      warn(
+        `Primary workspace is already locked; continuing without acquiring a lock for this run: ${err as Error}`
+      );
+    } else {
+      throw err;
+    }
+  }
 
   return { baseDir, planFile, workspaceTaskId, isNewWorkspace };
 }


### PR DESCRIPTION
### Motivation

- Generation should be allowed to run in the repository's primary workspace even when another process holds a lock there, to avoid blocked workflows when running `tim generate` from the repo root.

### Description

- Added `WorkspaceSetupOptions.allowPrimaryWorkspaceWhenLocked?: boolean` and updated `setupWorkspace()` to catch lock acquisition failures that contain “already locked” and, when the new option is enabled, continue with a warning instead of throwing. 
- Updated the `tim generate` command to pass `allowPrimaryWorkspaceWhenLocked: true` so generation proceeds in the primary workspace regardless of an existing lock.
- Added unit tests in `workspace_setup.test.ts` validating the new fallback behavior and that non-lock errors still fail, and updated `generate.test.ts` to assert the new option is passed through.

### Testing

- Ran `bun test src/tim/workspace/workspace_setup.test.ts` and all tests passed.
- Ran `bun test src/tim/commands/generate.test.ts --test-name-pattern "passes workspace options to setupWorkspace"` and the targeted test passed.
- Running the full `bun test` that includes `generate` integration scenarios produced failures related to Git fetch / missing temporary files (errors: "not a git repository" and several `ENOENT` plan file opens), which appear to be environment/repo-initialization issues unrelated to this change.
- Ran `bun run format` successfully and ran `bun run check` which reported pre-existing TypeScript errors in unrelated files (`src/common/terminal.ts`, `src/tim/db/plan.ts`, and `src/tim/db/plan_sync.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7ee95e68832487cdcb96d6500faa)