### PR TITLE
Reuse plan branches across workspace allocations

### DIFF
--- a/src/tim/workspace/workspace_setup.test.ts
+++ b/src/tim/workspace/workspace_setup.test.ts
@@ -12,6 +12,7 @@ import { WorkspaceAutoSelector } from './workspace_auto_selector.js';
 import { WorkspaceLock } from './workspace_lock.js';
 import * as workspaceCommand from '../commands/workspace.js';
 import * as workspaceManager from './workspace_manager.js';
+import * as processUtils from '../../common/process.js';
 import { setupWorkspace } from './workspace_setup.js';
 
 describe('setupWorkspace', () => {
@@ -727,6 +728,108 @@ describe('setupWorkspace', () => {
 
     expect(result.baseDir).toBe(existingWorkspacePath);
     expect(result.workspaceTaskId).toBe('task-update-fail-soft');
+  });
+
+  test('updates plan branch metadata to the allocated workspace branch', async () => {
+    const existingWorkspacePath = path.join(tempDir, 'workspace-existing-branch-metadata');
+    await fs.mkdir(existingWorkspacePath, { recursive: true });
+    await seedWorkspace(existingWorkspacePath, 'task-existing-branch-metadata');
+
+    const validPlanFile = path.join(baseDir, 'branch-metadata.plan.md');
+    await fs.writeFile(
+      validPlanFile,
+      ['---', 'id: 88', 'title: Keep branch metadata in sync', 'tasks: []', '---', ''].join('\n')
+    );
+
+    spyOn(git, 'getWorkingCopyStatus').mockResolvedValue({
+      hasChanges: false,
+      checkFailed: false,
+    });
+    const prepareSpy = spyOn(workspaceManager, 'prepareExistingWorkspace').mockResolvedValue({
+      success: true,
+      actualBranchName: '88-keep-branch-metadata-in-sync-2',
+    });
+    spyOn(workspaceManager, 'runWorkspaceUpdateCommands').mockResolvedValue(true);
+
+    await setupWorkspace(
+      {
+        workspace: 'task-existing-branch-metadata',
+      },
+      baseDir,
+      validPlanFile,
+      config,
+      'tim generate'
+    );
+
+    expect(prepareSpy).toHaveBeenCalledWith(existingWorkspacePath, {
+      baseBranch: undefined,
+      branchName: '88-keep-branch-metadata-in-sync',
+      createBranch: true,
+    });
+    expect(await fs.readFile(validPlanFile, 'utf8')).toContain(
+      'branch: 88-keep-branch-metadata-in-sync-2'
+    );
+  });
+
+  test('uses parent plan branch as base when available in the workspace repository', async () => {
+    const existingWorkspacePath = path.join(tempDir, 'workspace-existing-parent-base');
+    await fs.mkdir(existingWorkspacePath, { recursive: true });
+    await seedWorkspace(existingWorkspacePath, 'task-existing-parent-base');
+
+    const parentPlanFile = path.join(baseDir, 'parent.plan.md');
+    const childPlanFile = path.join(baseDir, 'child.plan.md');
+    await fs.writeFile(
+      parentPlanFile,
+      [
+        '---',
+        'id: 20',
+        'title: Parent plan',
+        'branch: feature/parent-plan',
+        'tasks: []',
+        '---',
+        '',
+      ].join('\n')
+    );
+    await fs.writeFile(
+      childPlanFile,
+      ['---', 'id: 21', 'title: Child plan', 'parent: 20', 'tasks: []', '---', ''].join('\n')
+    );
+
+    spyOn(git, 'getWorkingCopyStatus').mockResolvedValue({
+      hasChanges: false,
+      checkFailed: false,
+    });
+    spyOn(processUtils, 'spawnAndLogOutput').mockImplementation(async (args) => {
+      const cmd = Array.isArray(args) ? args.join(' ') : String(args);
+      if (cmd.includes('refs/heads/feature/parent-plan')) {
+        return { exitCode: 0, stdout: '', stderr: '' };
+      }
+      if (cmd.includes('refs/remotes/origin/feature/parent-plan')) {
+        return { exitCode: 1, stdout: '', stderr: '' };
+      }
+      return { exitCode: 1, stdout: '', stderr: '' };
+    });
+
+    const prepareSpy = spyOn(workspaceManager, 'prepareExistingWorkspace').mockResolvedValue({
+      success: true,
+    });
+    spyOn(workspaceManager, 'runWorkspaceUpdateCommands').mockResolvedValue(true);
+
+    await setupWorkspace(
+      {
+        workspace: 'task-existing-parent-base',
+      },
+      baseDir,
+      childPlanFile,
+      config,
+      'tim generate'
+    );
+
+    expect(prepareSpy).toHaveBeenCalledWith(existingWorkspacePath, {
+      baseBranch: 'feature/parent-plan',
+      branchName: '21-child-plan',
+      createBranch: true,
+    });
   });
 
   test('passes --base through as baseBranch for existing workspace preparation', async () => {

--- a/src/tim/workspace/workspace_setup.ts
+++ b/src/tim/workspace/workspace_setup.ts
@@ -1,12 +1,13 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { getCurrentBranchName, getUsingJj, getWorkingCopyStatus } from '../../common/git.js';
-import { logSpawn } from '../../common/process.js';
+import { logSpawn, spawnAndLogOutput } from '../../common/process.js';
 import { error, log, sendStructured, warn } from '../../logging.js';
 import { generateBranchNameFromPlan } from '../commands/branch.js';
 import { pullWorkspaceRefIfExists } from '../commands/workspace.js';
 import type { TimConfig } from '../configSchema.js';
-import { readPlanFile } from '../plans.js';
+import { readAllPlans, readPlanFile, writePlanFile } from '../plans.js';
+import type { PlanSchema } from '../planSchema.js';
 import { WorkspaceAutoSelector } from './workspace_auto_selector.js';
 import { findWorkspaceInfosByTaskId } from './workspace_info.js';
 import { WorkspaceLock } from './workspace_lock.js';
@@ -36,6 +37,68 @@ export interface WorkspaceSetupResult {
 
 function timestamp(): string {
   return new Date().toISOString();
+}
+
+async function branchExistsInWorkspace(workspacePath: string, branch: string): Promise<boolean> {
+  const usingJj = await getUsingJj(workspacePath);
+
+  if (usingJj) {
+    const branchList = await spawnAndLogOutput(['jj', 'bookmark', 'list', branch], {
+      cwd: workspacePath,
+      quiet: true,
+    });
+
+    if (branchList.exitCode !== 0) {
+      return false;
+    }
+
+    return branchList.stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .some((line) => line.startsWith(`${branch} `) || line === branch);
+  }
+
+  const localRef = await spawnAndLogOutput(
+    ['git', 'show-ref', '--verify', '--quiet', `refs/heads/${branch}`],
+    {
+      cwd: workspacePath,
+      quiet: true,
+    }
+  );
+  if (localRef.exitCode === 0) {
+    return true;
+  }
+
+  const remoteRef = await spawnAndLogOutput(
+    ['git', 'show-ref', '--verify', '--quiet', `refs/remotes/origin/${branch}`],
+    {
+      cwd: workspacePath,
+      quiet: true,
+    }
+  );
+  return remoteRef.exitCode === 0;
+}
+
+async function getParentPlanBranch(
+  planFile: string,
+  plan: PlanSchema
+): Promise<string | undefined> {
+  if (!plan.parent) {
+    return undefined;
+  }
+
+  const { plans } = await readAllPlans(path.dirname(planFile), false);
+  return plans.get(plan.parent)?.branch;
+}
+
+async function updatePlanBranchMetadata(planFile: string, branch: string): Promise<void> {
+  const plan = await readPlanFile(planFile);
+  if (plan.branch === branch) {
+    return;
+  }
+
+  plan.branch = branch;
+  await writePlanFile(planFile, plan);
 }
 
 export async function setupWorkspace(
@@ -182,9 +245,28 @@ export async function setupWorkspace(
           }
 
           let branchName = workspace.taskId;
+          let planData: PlanSchema | undefined;
+          let baseBranch = options.base;
           try {
-            const plan = await readPlanFile(planFile);
-            branchName = generateBranchNameFromPlan(plan);
+            planData = await readPlanFile(planFile);
+            branchName = planData.branch ?? generateBranchNameFromPlan(planData);
+
+            if (!baseBranch && !planData.baseBranch) {
+              const parentBranch = await getParentPlanBranch(planFile, planData);
+              if (parentBranch) {
+                const parentBranchExists = await branchExistsInWorkspace(
+                  workspace.path,
+                  parentBranch
+                );
+                if (parentBranchExists) {
+                  baseBranch = parentBranch;
+                }
+              }
+            }
+
+            if (!baseBranch) {
+              baseBranch = planData.baseBranch;
+            }
           } catch (err) {
             warn(
               `Failed to generate branch name from plan file ${planFile}. Falling back to workspace task ID: ${err as Error}`
@@ -194,7 +276,7 @@ export async function setupWorkspace(
           let preparedWithPlanBranch = false;
           if (options.autoWorkspace) {
             const syncBaseResult = await prepareExistingWorkspace(workspace.path, {
-              baseBranch: options.base,
+              baseBranch,
               branchName,
               createBranch: false,
             });
@@ -219,15 +301,33 @@ export async function setupWorkspace(
           }
 
           if (!preparedWithPlanBranch) {
-            const prepareResult = await prepareExistingWorkspace(workspace.path, {
-              baseBranch: options.base,
+            let prepareResult = await prepareExistingWorkspace(workspace.path, {
+              baseBranch,
               branchName,
               createBranch: config.workspaceCreation?.createBranch ?? true,
             });
+
+            if (!prepareResult.success && baseBranch && !options.base) {
+              prepareResult = await prepareExistingWorkspace(workspace.path, {
+                branchName,
+                createBranch: config.workspaceCreation?.createBranch ?? true,
+              });
+            }
+
             if (!prepareResult.success) {
               throw new Error(
                 `Failed to prepare workspace at ${workspace.path}: ${prepareResult.error ?? 'Unknown error'}`
               );
+            }
+
+            if (prepareResult.actualBranchName) {
+              try {
+                await updatePlanBranchMetadata(planFile, prepareResult.actualBranchName);
+              } catch (err) {
+                warn(
+                  `Failed to update plan branch metadata after workspace preparation: ${err as Error}`
+                );
+              }
             }
           }
 


### PR DESCRIPTION
### Motivation

- Ensure workspaces reuse and track the same branch names recorded in plan metadata so commands run in different workspaces remain consistent.
- Use a parent plan's branch as the base when creating a child plan workspace to preserve intended lineage for multi-plan generation flows.
- Fall back to the trunk/default base when a derived parent branch is no longer present so workspace preparation remains robust.

### Description

- Added branch discovery and plan-branch helper functions in `src/tim/workspace/workspace_setup.ts`: `branchExistsInWorkspace`, `getParentPlanBranch`, and `updatePlanBranchMetadata` to detect branches in Git/jj repos and persist allocated branch names.
- Prefer an existing `plan.branch` (if present) when deriving the workspace branch name and attempt to use a parent plan's branch as `baseBranch` for child plans when available in the target workspace repository.
- If a derived `baseBranch` fails to prepare and the `--base` option was not explicitly provided, retry preparation using the default/trunk path to avoid hard failures.
- Added tests in `src/tim/workspace/workspace_setup.test.ts` that assert plan `branch` metadata is updated to the allocated branch and that a parent plan branch is used as the child plan base when detectable.

### Testing

- Ran `bun run format` which completed successfully.
- Ran `bun test src/tim/workspace/workspace_setup.test.ts` and all tests in that file passed (34 passed, 0 failed).
- Ran `bun run check` which failed due to pre-existing TypeScript issues outside of these changes (errors reported in unrelated files), and did not indicate failures introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac7ff27aa483248c9ca6ebf47ff142)