### PR TITLE
Fix TypeScript errors in terminal stdin handling and plan sync/type coercions

### DIFF
--- a/src/common/terminal.ts
+++ b/src/common/terminal.ts
@@ -35,17 +35,20 @@ export async function waitForEnter(readClipboard = false) {
  * @param timeoutMs How long to wait for more input before considering the input complete
  * @returns The complete input as a string
  */
-export async function readStdinUntilTimeout(initialData: Buffer, timeoutMs = 250): Promise<string> {
+export async function readStdinUntilTimeout(
+  initialData: Buffer | string,
+  timeoutMs = 250
+): Promise<string> {
   // Start with the initial data
-  let input = initialData.toString();
+  let input = typeof initialData === 'string' ? initialData : initialData.toString();
 
   return new Promise<string>((resolve) => {
     let timeoutId: NodeJS.Timeout | null = null;
 
     // Set up the data handler
-    const dataHandler = (chunk: Buffer) => {
+    const dataHandler = (chunk: Buffer | string) => {
       // Add the new data to our input
-      input += chunk.toString();
+      input += typeof chunk === 'string' ? chunk : chunk.toString();
 
       // Reset the timeout
       if (timeoutId) {

--- a/src/tim/db/plan.ts
+++ b/src/tim/db/plan.ts
@@ -159,9 +159,11 @@ export function upsertPlan(db: Database, projectId: number, input: UpsertPlanInp
     (nextProjectId: number, nextInput: UpsertPlanInput): PlanRow => {
       const existing = getPlanByUuid(db, nextInput.uuid);
       const incomingTimestamp = parseTimestamp(nextInput.sourceUpdatedAt);
-      const effectiveUpdatedAt = incomingTimestamp === null ? null : nextInput.sourceUpdatedAt;
+      const effectiveUpdatedAt =
+        incomingTimestamp === null ? null : (nextInput.sourceUpdatedAt ?? null);
       const incomingCreatedAt = parseTimestamp(nextInput.sourceCreatedAt);
-      const effectiveCreatedAt = incomingCreatedAt === null ? null : nextInput.sourceCreatedAt;
+      const effectiveCreatedAt =
+        incomingCreatedAt === null ? null : (nextInput.sourceCreatedAt ?? null);
       if (existing && nextInput.forceOverwrite !== true) {
         const existingTimestamp = parseTimestamp(existing.updated_at);
         if (

--- a/src/tim/db/plan_sync.ts
+++ b/src/tim/db/plan_sync.ts
@@ -154,6 +154,7 @@ function toPlanUpsertInput(
   title?: string | null;
   goal?: string | null;
   details?: string | null;
+  sourceCreatedAt?: string | null;
   sourceUpdatedAt?: string | null;
   status: PlanSchema['status'];
   priority?: 'low' | 'medium' | 'high' | 'urgent' | 'maybe' | null;


### PR DESCRIPTION
### Motivation

- Resolve TypeScript errors caused by `process.stdin` event payload typing and mismatched plan sync object shapes to make `bun run check` succeed. 
- Prevent `undefined` values from being passed into sqlite bindings for plan timestamps to avoid runtime/binding type issues. 

### Description

- Update `readStdinUntilTimeout` in `src/common/terminal.ts` to accept `Buffer | string` for `initialData` and `data` chunks and safely append either type. 
- Coerce optional plan timestamp fields in `src/tim/db/plan.ts` so `effectiveCreatedAt` / `effectiveUpdatedAt` are `null` instead of possibly `undefined` before passing to sqlite `.run()` bindings. 
- Add `sourceCreatedAt` to the typed output shape returned by `toPlanUpsertInput` in `src/tim/db/plan_sync.ts` so the object literal matches the declared type. 

### Testing

- Ran type checking with `bun run check`, which now passes. 
- Ran code formatting with `bun run format`, which completed successfully. 
- Ran the test suite with `bun test`; the run completed but there are pre-existing unrelated failing tests (several tests in `src/tim`), and the failures are not caused by these type fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac909807b883248dba19d969df5a88)