### PR TITLE
Ensure jj pushes create a fresh working change when working copy is non-empty

### DIFF
--- a/src/tim/commands/workspace.push.test.ts
+++ b/src/tim/commands/workspace.push.test.ts
@@ -387,6 +387,7 @@ describe('handleWorkspacePushCommand', () => {
 
     await moduleMocker.mock('../../common/git.js', () => ({
       getCurrentBranchName: mock(async () => 'feature/jj-match'),
+      getJjBookmarkRevisionForWorkingCopy: mock(async () => '@-'),
       getUsingJj: mock(async () => true),
     }));
     await moduleMocker.mock('../../common/process.js', () => ({
@@ -431,6 +432,76 @@ describe('handleWorkspacePushCommand', () => {
           args[0] === 'jj' && args[1] === 'git' && args[2] === 'remote' && args[3] === 'set-url'
       )
     ).toBe(false);
+    expect(
+      processCalls.some((args) => args[0] === 'jj' && args[1] === 'new' && args[2] === '@')
+    ).toBe(false);
+  });
+
+  test('jj mode creates a new working change after push when working copy is non-empty', async () => {
+    const repositoryId = 'workspace-push-jj-new-after-push';
+    const primaryDir = path.join(tempRoot, 'primary-jj-new');
+    const secondaryDir = path.join(tempRoot, 'secondary-jj-new');
+
+    await fs.mkdir(primaryDir, { recursive: true });
+    await fs.mkdir(secondaryDir, { recursive: true });
+
+    recordWorkspaceForRepo({
+      workspacePath: primaryDir,
+      taskId: 'task-primary',
+      repositoryId,
+      branch: 'main',
+      workspaceType: 'primary',
+    });
+    recordWorkspaceForRepo({
+      workspacePath: secondaryDir,
+      taskId: 'task-secondary',
+      repositoryId,
+      branch: 'feature/jj-new',
+    });
+
+    const processCalls: string[][] = [];
+
+    await moduleMocker.mock('../../common/git.js', () => ({
+      getCurrentBranchName: mock(async () => 'feature/jj-new'),
+      getJjBookmarkRevisionForWorkingCopy: mock(async () => '@'),
+      getUsingJj: mock(async () => true),
+    }));
+    await moduleMocker.mock('../../common/process.js', () => ({
+      spawnAndLogOutput: mock(async (args: string[]) => {
+        processCalls.push(args);
+
+        if (args[0] === 'jj' && args[1] === 'git' && args[2] === 'remote' && args[3] === 'list') {
+          return {
+            exitCode: 0,
+            stdout: `origin /tmp/origin\nprimary ${primaryDir}\n`,
+            stderr: '',
+          };
+        }
+
+        return {
+          exitCode: 0,
+          stdout: '',
+          stderr: '',
+        };
+      }),
+    }));
+
+    const { handleWorkspacePushCommand } = await import('./workspace.js');
+
+    await expect(
+      handleWorkspacePushCommand(undefined, { from: secondaryDir }, {} as any)
+    ).resolves.toBeUndefined();
+
+    expect(processCalls).toContainEqual([
+      'jj',
+      'git',
+      'push',
+      '--remote',
+      'primary',
+      '--bookmark',
+      'feature/jj-new',
+    ]);
+    expect(processCalls).toContainEqual(['jj', 'new', '@']);
   });
 
   test('supports explicit --from, --to, and --branch options', async () => {

--- a/src/tim/commands/workspace.ts
+++ b/src/tim/commands/workspace.ts
@@ -1814,6 +1814,8 @@ async function pushJjBookmarkToWorkspace(
   bookmark: string,
   remoteName: string
 ): Promise<void> {
+  const workingCopyRevisionBeforePush = await getJjBookmarkRevisionForWorkingCopy(workspacePath);
+
   const trackOutput = await spawnAndLogOutput(
     ['jj', 'bookmark', 'track', bookmark, '--remote', remoteName],
     { cwd: workspacePath }
@@ -1830,6 +1832,15 @@ async function pushJjBookmarkToWorkspace(
   );
   if (pushResult.exitCode !== 0) {
     throw new Error(`Failed to push bookmark "${bookmark}" to ${remoteName}: ${pushResult.stderr}`);
+  }
+
+  if (workingCopyRevisionBeforePush === '@') {
+    const newResult = await spawnAndLogOutput(['jj', 'new', '@'], { cwd: workspacePath });
+    if (newResult.exitCode !== 0) {
+      throw new Error(
+        `Failed to create a new working change after pushing bookmark "${bookmark}": ${newResult.stderr}`
+      );
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent divergent history when syncing Jujutsu (jj) workspaces by ensuring further edits after a bookmark push do not accumulate on the already-pushed working commit.
- Only create a new working change for non-empty working copies and keep existing behavior for empty working-copy states (`@-`).

### Description
- Update `pushJjBookmarkToWorkspace()` to call `getJjBookmarkRevisionForWorkingCopy()` before pushing and, after a successful `jj git push`, run `jj new @` when the pre-push revision was `@` (non-empty working copy).
- Extend `src/tim/commands/workspace.push.test.ts` to mock `getJjBookmarkRevisionForWorkingCopy()` and add tests asserting both cases: no `jj new` when working copy is `@-`, and `jj new @` is invoked when working copy is `@`.
- No behavioral changes were made for the Git code paths; only the jj workflow is adjusted.

### Testing
- Ran `bun install` successfully to ensure dependencies were present.
- Ran `bun run test-cli src/tim/commands/workspace.push.test.ts` and all tests in that file passed (9 passed).
- Ran `bun run format` successfully to apply formatting.
- Ran `bun run check` which failed due to a pre-existing, unrelated TypeScript error in `src/tim/review_runner.ts` and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be21a6a8e88324ade35934aeb362f4)