### PR TITLE
Add media host server for file uploads and signed downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -740,6 +740,39 @@ When a timeout is exceeded, tim sends `SIGTERM`, waits 5 seconds, then sends `SI
 
 Target leaf commands, such as `vitest run` or `pnpm test`, rather than broad process names like `node` or `bash`. The root executor PID is excluded automatically, but descendant shells are not. The monitor only runs during agent sessions that spawn Claude Code or Codex executors.
 
+## Media Host
+
+`bun run media-host` starts a small standalone Bun server (`src/media-host/server.ts`) for hosting uploaded text, images, and small videos. Uploads are gated by a bearer API key; reads are gated by a salted hash of the file path, so a URL can only be read by someone holding a signature minted from the signing secret.
+
+Configuration is read from the environment:
+
+| Variable                      | Required | Default                   | Purpose                                           |
+| ----------------------------- | -------- | ------------------------- | ------------------------------------------------- |
+| `MEDIA_HOST_API_KEY`          | yes      | —                         | Bearer token required to upload files             |
+| `MEDIA_HOST_SIGNING_SECRET`   | yes      | —                         | Secret (salt) used to sign and verify read access |
+| `MEDIA_HOST_DIR`              | no       | `~/.cache/tim/media-host` | Directory that stores uploaded files              |
+| `MEDIA_HOST_PORT`             | no       | `8125`                    | Listen port                                       |
+| `MEDIA_HOST_HOST`             | no       | `0.0.0.0`                 | Listen host                                       |
+| `MEDIA_HOST_MAX_UPLOAD_BYTES` | no       | `104857600` (100 MiB)     | Maximum upload size; larger uploads return `413`  |
+
+**Upload** with `PUT` (or `POST`) to any path and a bearer token. The response includes the path-bound read URL:
+
+```bash
+curl -X PUT \
+  -H "Authorization: Bearer $MEDIA_HOST_API_KEY" \
+  --data-binary @cat.png \
+  http://localhost:8125/images/cat.png
+# => {"path":"images/cat.png","size":12345,"url":"/images/cat.png?sig=<hash>"}
+```
+
+**Read** by appending the `sig` query parameter from the upload response. The content type is inferred from the file extension. Requests without a valid signature get `403`:
+
+```bash
+curl "http://localhost:8125/images/cat.png?sig=<hash>"
+```
+
+Upload paths are confined to the storage directory — path-traversal attempts (including percent-encoded separators) are rejected with `400`.
+
 ## Known Issues and Workarounds
 
 **Missing branch prefix**

--- a/README.md
+++ b/README.md
@@ -746,14 +746,14 @@ Target leaf commands, such as `vitest run` or `pnpm test`, rather than broad pro
 
 Configuration is read from the environment:
 
-| Variable                      | Required | Default                   | Purpose                                           |
-| ----------------------------- | -------- | ------------------------- | ------------------------------------------------- |
-| `MEDIA_HOST_API_KEY`          | yes      | —                         | Bearer token required to upload files             |
-| `MEDIA_HOST_SIGNING_SECRET`   | yes      | —                         | Secret (salt) used to sign and verify read access |
-| `MEDIA_HOST_DIR`              | no       | `~/.cache/tim/media-host` | Directory that stores uploaded files              |
-| `MEDIA_HOST_PORT`             | no       | `8125`                    | Listen port                                       |
-| `MEDIA_HOST_HOST`             | no       | `0.0.0.0`                 | Listen host                                       |
-| `MEDIA_HOST_MAX_UPLOAD_BYTES` | no       | `104857600` (100 MiB)     | Maximum upload size; larger uploads return `413`  |
+| Variable                      | Required | Default                         | Purpose                                           |
+| ----------------------------- | -------- | ------------------------------- | ------------------------------------------------- |
+| `MEDIA_HOST_API_KEY`          | yes      | —                               | Bearer token required to upload files             |
+| `MEDIA_HOST_SIGNING_SECRET`   | yes      | —                               | Secret (salt) used to sign and verify read access |
+| `MEDIA_HOST_DIR`              | no       | `~/.local/share/tim/media-host` | Directory that stores uploaded files              |
+| `MEDIA_HOST_PORT`             | no       | `8125`                          | Listen port                                       |
+| `MEDIA_HOST_HOST`             | no       | `0.0.0.0`                       | Listen host                                       |
+| `MEDIA_HOST_MAX_UPLOAD_BYTES` | no       | `104857600` (100 MiB)           | Maximum upload size; larger uploads return `413`  |
 
 **Upload** with `PUT` (or `POST`) to any path and a bearer token. The response includes the path-bound read URL:
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "test": "bun --bun vitest run --project server",
     "test:client": "bun --bun vitest run --project client",
     "tim": "src/tim/tim.ts",
-    "webhook-receiver": "bun run src/webhooks/server.ts"
+    "webhook-receiver": "bun run src/webhooks/server.ts",
+    "media-host": "bun run src/media-host/server.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^1.2.12",

--- a/src/media-host/security.test.ts
+++ b/src/media-host/security.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  computePathSignature,
+  constantTimeEquals,
+  hasValidBearerToken,
+  isValidPathSignature,
+} from './security.js';
+
+describe('media-host/security', () => {
+  test('constantTimeEquals matches equal strings', () => {
+    expect(constantTimeEquals('abc123', 'abc123')).toBe(true);
+  });
+
+  test('constantTimeEquals rejects differing values and lengths', () => {
+    expect(constantTimeEquals('abc', 'abd')).toBe(false);
+    expect(constantTimeEquals('abc', 'abcd')).toBe(false);
+  });
+
+  test('hasValidBearerToken validates the bearer token', () => {
+    const request = new Request('https://example.com/foo.png', {
+      headers: { authorization: 'Bearer shared-secret' },
+    });
+
+    expect(hasValidBearerToken(request, 'shared-secret')).toBe(true);
+    expect(hasValidBearerToken(request, 'wrong-secret')).toBe(false);
+  });
+
+  test('hasValidBearerToken rejects missing or malformed headers', () => {
+    expect(hasValidBearerToken(new Request('https://example.com/foo.png'), 'secret')).toBe(false);
+
+    const basic = new Request('https://example.com/foo.png', {
+      headers: { authorization: 'Basic shared-secret' },
+    });
+    expect(hasValidBearerToken(basic, 'shared-secret')).toBe(false);
+  });
+
+  test('computePathSignature is deterministic and salted by the secret', () => {
+    const a = computePathSignature('images/cat.png', 'salt-one');
+    const b = computePathSignature('images/cat.png', 'salt-one');
+    const c = computePathSignature('images/cat.png', 'salt-two');
+
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('computePathSignature differs per path', () => {
+    const secret = 'salt';
+    expect(computePathSignature('a/cat.png', secret)).not.toBe(
+      computePathSignature('b/cat.png', secret)
+    );
+  });
+
+  test('isValidPathSignature accepts the matching signature only', () => {
+    const secret = 'salt';
+    const path = 'videos/clip.mp4';
+    const signature = computePathSignature(path, secret);
+
+    expect(isValidPathSignature(path, secret, signature)).toBe(true);
+    expect(isValidPathSignature(path, secret, signature.replace(/.$/, '0'))).toBe(false);
+    // A signature for a different path must not grant access to this one.
+    expect(
+      isValidPathSignature(path, secret, computePathSignature('videos/other.mp4', secret))
+    ).toBe(false);
+  });
+
+  test('isValidPathSignature rejects missing signatures', () => {
+    expect(isValidPathSignature('a.png', 'salt', null)).toBe(false);
+    expect(isValidPathSignature('a.png', 'salt', undefined)).toBe(false);
+    expect(isValidPathSignature('a.png', 'salt', '')).toBe(false);
+  });
+});

--- a/src/media-host/security.ts
+++ b/src/media-host/security.ts
@@ -1,0 +1,64 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Compares two strings in constant time to avoid leaking information through
+ * timing side channels. Returns false immediately when lengths differ.
+ */
+export function constantTimeEquals(left: string, right: string): boolean {
+  const leftBuffer = Buffer.from(left, 'utf8');
+  const rightBuffer = Buffer.from(right, 'utf8');
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+/**
+ * Validates that a request carries the expected bearer token in its
+ * Authorization header. Used to gate uploads.
+ */
+export function hasValidBearerToken(request: Request, expectedToken: string): boolean {
+  const header = request.headers.get('authorization');
+  if (!header) {
+    return false;
+  }
+
+  const [scheme, token] = header.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) {
+    return false;
+  }
+
+  return constantTimeEquals(token, expectedToken);
+}
+
+/**
+ * Computes the salted hash (HMAC-SHA256) of a file path. The signing secret acts
+ * as the salt, so the signature cannot be forged or recomputed without it. The
+ * same path always yields the same signature for a given secret, which lets a
+ * signed URL be reused for the lifetime of the file.
+ *
+ * @param relativePath - The canonical, normalized storage-relative path
+ * @param secret - The signing secret (salt)
+ * @returns A lowercase hex-encoded HMAC digest
+ */
+export function computePathSignature(relativePath: string, secret: string): string {
+  return createHmac('sha256', secret).update(relativePath, 'utf8').digest('hex');
+}
+
+/**
+ * Verifies that a provided signature matches the expected salted hash of the
+ * given path. Comparison is constant time.
+ */
+export function isValidPathSignature(
+  relativePath: string,
+  secret: string,
+  providedSignature: string | null | undefined
+): boolean {
+  if (!providedSignature) {
+    return false;
+  }
+
+  const expected = computePathSignature(relativePath, secret);
+  return constantTimeEquals(expected, providedSignature);
+}

--- a/src/media-host/server.test.ts
+++ b/src/media-host/server.test.ts
@@ -83,6 +83,21 @@ describe('media-host server', () => {
     expect(onDisk).toBe('hello world');
   });
 
+  test('returns a signed url with reserved path characters encoded', async () => {
+    const res = await upload('docs/a%3Fb%23c.txt', 'reserved');
+    expect(res.status).toBe(201);
+
+    const payload = (await res.json()) as { path: string; size: number; url: string };
+    expect(payload.path).toBe('docs/a?b#c.txt');
+
+    const expectedSig = computePathSignature('docs/a?b#c.txt', SIGNING_SECRET);
+    expect(payload.url).toBe(`/docs/a%3Fb%23c.txt?sig=${expectedSig}`);
+
+    const download = await fetch(`${baseUrl}${payload.url}`);
+    expect(download.status).toBe(200);
+    expect(await download.text()).toBe('reserved');
+  });
+
   test('rejects uploads without a valid token', async () => {
     const noToken = await fetch(`${baseUrl}/docs/readme.txt`, { method: 'PUT', body: 'x' });
     expect(noToken.status).toBe(401);

--- a/src/media-host/server.test.ts
+++ b/src/media-host/server.test.ts
@@ -1,0 +1,166 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { computePathSignature } from './security.js';
+import { buildServer, createFetchHandler, normalizeMediaPath } from './server.js';
+import type { MediaHostConfig } from './server.js';
+
+const API_KEY = 'test-api-key';
+const SIGNING_SECRET = 'test-signing-secret';
+
+describe('media-host/normalizeMediaPath', () => {
+  test('strips leading slashes and decodes', () => {
+    expect(normalizeMediaPath('/images/cat.png')).toBe('images/cat.png');
+    expect(normalizeMediaPath('/images/my%20cat.png')).toBe('images/my cat.png');
+  });
+
+  test('rejects empty paths and directory-like paths', () => {
+    expect(normalizeMediaPath('/')).toBe(null);
+    expect(normalizeMediaPath('')).toBe(null);
+    expect(normalizeMediaPath('/images/')).toBe(null);
+  });
+
+  test('rejects NUL bytes', () => {
+    expect(normalizeMediaPath('/images/%00cat.png')).toBe(null);
+  });
+});
+
+describe('media-host server', () => {
+  let storageDir: string;
+  let server: ReturnType<typeof buildServer>;
+  let baseUrl: string;
+  let config: MediaHostConfig;
+
+  beforeEach(async () => {
+    storageDir = await fs.mkdtemp(path.join(os.tmpdir(), 'media-host-test-'));
+    config = {
+      port: 0,
+      host: '127.0.0.1',
+      storageDir,
+      apiKey: API_KEY,
+      signingSecret: SIGNING_SECRET,
+      maxUploadBytes: 1024,
+    };
+    server = buildServer(config);
+    baseUrl = `http://127.0.0.1:${server.port}`;
+  });
+
+  afterEach(async () => {
+    await server.stop(true);
+    await fs.rm(storageDir, { recursive: true, force: true });
+  });
+
+  async function upload(relativePath: string, body: BodyInit, token = API_KEY): Promise<Response> {
+    return fetch(`${baseUrl}/${relativePath}`, {
+      method: 'PUT',
+      headers: { authorization: `Bearer ${token}` },
+      body,
+    });
+  }
+
+  test('health check responds', async () => {
+    const res = await fetch(`${baseUrl}/healthz`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  test('uploads a file with a valid bearer token and returns a signed url', async () => {
+    const res = await upload('docs/readme.txt', 'hello world');
+    expect(res.status).toBe(201);
+
+    const payload = (await res.json()) as { path: string; size: number; url: string };
+    expect(payload.path).toBe('docs/readme.txt');
+    expect(payload.size).toBe('hello world'.length);
+
+    const expectedSig = computePathSignature('docs/readme.txt', SIGNING_SECRET);
+    expect(payload.url).toBe(`/docs/readme.txt?sig=${expectedSig}`);
+
+    // The file actually landed on disk inside the storage dir.
+    const onDisk = await fs.readFile(path.join(storageDir, 'docs/readme.txt'), 'utf8');
+    expect(onDisk).toBe('hello world');
+  });
+
+  test('rejects uploads without a valid token', async () => {
+    const noToken = await fetch(`${baseUrl}/docs/readme.txt`, { method: 'PUT', body: 'x' });
+    expect(noToken.status).toBe(401);
+
+    const wrongToken = await upload('docs/readme.txt', 'x', 'nope');
+    expect(wrongToken.status).toBe(401);
+
+    // Nothing should have been written.
+    await expect(fs.access(path.join(storageDir, 'docs/readme.txt'))).rejects.toThrow();
+  });
+
+  test('rejects uploads exceeding the max size', async () => {
+    const tooBig = 'a'.repeat(2048);
+    const res = await upload('big.bin', tooBig);
+    expect(res.status).toBe(413);
+  });
+
+  test('rejects percent-encoded path traversal in uploads', async () => {
+    // The URL parser resolves literal `../` dot-segments before we ever see the
+    // pathname, so the real smuggling vector is an encoded slash (`%2f`): it
+    // survives URL parsing and only becomes a separator once we decode it.
+    // validatePath must reject the resulting escape.
+    const handler = createFetchHandler(config);
+    const res = await handler(
+      new Request(`${baseUrl}/..%2fescape.txt`, {
+        method: 'PUT',
+        headers: { authorization: `Bearer ${API_KEY}` },
+        body: 'x',
+      })
+    );
+    expect(res.status).toBe(400);
+    await expect(fs.access(path.join(storageDir, '..', 'escape.txt'))).rejects.toThrow();
+  });
+
+  test('serves an uploaded file when the signature is valid', async () => {
+    await upload('images/pixel.png', 'PNGDATA');
+    const sig = computePathSignature('images/pixel.png', SIGNING_SECRET);
+
+    const res = await fetch(`${baseUrl}/images/pixel.png?sig=${sig}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('image/png');
+    expect(await res.text()).toBe('PNGDATA');
+  });
+
+  test('refuses access without or with an invalid signature', async () => {
+    await upload('images/pixel.png', 'PNGDATA');
+
+    const missing = await fetch(`${baseUrl}/images/pixel.png`);
+    expect(missing.status).toBe(403);
+
+    const wrong = await fetch(`${baseUrl}/images/pixel.png?sig=deadbeef`);
+    expect(wrong.status).toBe(403);
+
+    // A signature minted for a different path must not unlock this one.
+    const otherSig = computePathSignature('images/other.png', SIGNING_SECRET);
+    const crossPath = await fetch(`${baseUrl}/images/pixel.png?sig=${otherSig}`);
+    expect(crossPath.status).toBe(403);
+  });
+
+  test('returns 404 for a correctly signed but missing file', async () => {
+    const sig = computePathSignature('missing.txt', SIGNING_SECRET);
+    const res = await fetch(`${baseUrl}/missing.txt?sig=${sig}`);
+    expect(res.status).toBe(404);
+  });
+
+  test('round-trips binary content unchanged', async () => {
+    const bytes = new Uint8Array([0, 1, 2, 253, 254, 255]);
+    await upload('videos/clip.mp4', bytes);
+    const sig = computePathSignature('videos/clip.mp4', SIGNING_SECRET);
+
+    const res = await fetch(`${baseUrl}/videos/clip.mp4?sig=${sig}`);
+    expect(res.status).toBe(200);
+    expect(new Uint8Array(await res.arrayBuffer())).toEqual(bytes);
+  });
+
+  test('rejects unsupported methods', async () => {
+    const handler = createFetchHandler(config);
+    const res = await handler(new Request(`${baseUrl}/foo.txt`, { method: 'DELETE' }));
+    expect(res.status).toBe(405);
+  });
+});

--- a/src/media-host/server.ts
+++ b/src/media-host/server.ts
@@ -1,0 +1,233 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { validatePath } from '../common/fs.js';
+import { computePathSignature, hasValidBearerToken, isValidPathSignature } from './security.js';
+
+/** Query parameter that carries the salted-hash signature for read access. */
+export const SIGNATURE_PARAM = 'sig';
+
+export interface MediaHostConfig {
+  port: number;
+  host: string;
+  /** Directory under which all uploaded files are stored. */
+  storageDir: string;
+  /** Bearer token required to upload files. */
+  apiKey: string;
+  /** Secret (salt) used to sign and verify access to file paths. */
+  signingSecret: string;
+  /** Maximum upload size in bytes. Larger uploads are rejected with 413. */
+  maxUploadBytes: number;
+}
+
+function getDefaultStorageDir(): string {
+  return join(homedir(), '.cache', 'tim', 'media-host');
+}
+
+export function loadConfigFromEnv(): MediaHostConfig {
+  const apiKey = process.env.MEDIA_HOST_API_KEY;
+  const signingSecret = process.env.MEDIA_HOST_SIGNING_SECRET;
+
+  if (!apiKey) {
+    throw new Error('MEDIA_HOST_API_KEY is required');
+  }
+  if (!signingSecret) {
+    throw new Error('MEDIA_HOST_SIGNING_SECRET is required');
+  }
+
+  const port = Number.parseInt(process.env.MEDIA_HOST_PORT ?? '8125', 10);
+  if (!Number.isInteger(port) || port < 0 || port > 65535) {
+    throw new Error(`Invalid MEDIA_HOST_PORT: ${process.env.MEDIA_HOST_PORT}`);
+  }
+
+  const maxUploadBytes = Number.parseInt(
+    process.env.MEDIA_HOST_MAX_UPLOAD_BYTES ?? `${100 * 1024 * 1024}`,
+    10
+  );
+  if (!Number.isInteger(maxUploadBytes) || maxUploadBytes <= 0) {
+    throw new Error(
+      `Invalid MEDIA_HOST_MAX_UPLOAD_BYTES: ${process.env.MEDIA_HOST_MAX_UPLOAD_BYTES}`
+    );
+  }
+
+  return {
+    port,
+    host: process.env.MEDIA_HOST_HOST ?? '0.0.0.0',
+    storageDir: process.env.MEDIA_HOST_DIR ?? getDefaultStorageDir(),
+    apiKey,
+    signingSecret,
+    maxUploadBytes,
+  };
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+    },
+  });
+}
+
+/**
+ * Normalizes a request URL pathname into a canonical storage-relative path:
+ * decodes percent-encoding and strips leading slashes. Returns null when the
+ * pathname does not name a file (e.g. it is empty or ends in a slash).
+ *
+ * Path-traversal safety is enforced separately via {@link validatePath}; this
+ * function only produces the canonical string that is both signed and resolved.
+ */
+export function normalizeMediaPath(pathname: string): string | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    return null;
+  }
+
+  // Reject NUL bytes outright — they can truncate paths at the filesystem layer.
+  if (decoded.includes('\0')) {
+    return null;
+  }
+
+  const relativePath = decoded.replace(/^\/+/, '');
+  if (relativePath.length === 0 || relativePath.endsWith('/')) {
+    return null;
+  }
+
+  return relativePath;
+}
+
+async function handleUpload(
+  request: Request,
+  relativePath: string,
+  config: MediaHostConfig
+): Promise<Response> {
+  if (!hasValidBearerToken(request, config.apiKey)) {
+    return jsonResponse({ error: 'Unauthorized' }, 401);
+  }
+
+  let absoluteTargetPath: string;
+  try {
+    absoluteTargetPath = validatePath(config.storageDir, relativePath);
+  } catch {
+    return jsonResponse({ error: 'Invalid path' }, 400);
+  }
+
+  const declaredLength = request.headers.get('content-length');
+  if (declaredLength) {
+    const declared = Number.parseInt(declaredLength, 10);
+    if (Number.isInteger(declared) && declared > config.maxUploadBytes) {
+      return jsonResponse({ error: 'Payload too large' }, 413);
+    }
+  }
+
+  const body = await request.arrayBuffer();
+  if (body.byteLength > config.maxUploadBytes) {
+    return jsonResponse({ error: 'Payload too large' }, 413);
+  }
+
+  await Bun.write(absoluteTargetPath, body);
+
+  const signature = computePathSignature(relativePath, config.signingSecret);
+  return jsonResponse(
+    {
+      path: relativePath,
+      size: body.byteLength,
+      url: `/${relativePath}?${SIGNATURE_PARAM}=${signature}`,
+    },
+    201
+  );
+}
+
+async function handleDownload(
+  url: URL,
+  relativePath: string,
+  config: MediaHostConfig
+): Promise<Response> {
+  const signature = url.searchParams.get(SIGNATURE_PARAM);
+  if (!isValidPathSignature(relativePath, config.signingSecret, signature)) {
+    return jsonResponse({ error: 'Forbidden' }, 403);
+  }
+
+  let absoluteTargetPath: string;
+  try {
+    absoluteTargetPath = validatePath(config.storageDir, relativePath);
+  } catch {
+    return jsonResponse({ error: 'Invalid path' }, 400);
+  }
+
+  const file = Bun.file(absoluteTargetPath);
+  if (!(await file.exists())) {
+    return jsonResponse({ error: 'Not Found' }, 404);
+  }
+
+  // Response infers content-type and content-length from the BunFile. Files are
+  // gated behind a path-bound signature, so caches must keep responses private.
+  return new Response(file, {
+    headers: {
+      'cache-control': 'private, max-age=3600',
+    },
+  });
+}
+
+/**
+ * Builds the request handler for the media host. Exposed separately from
+ * {@link buildServer} so it can be exercised directly in tests.
+ */
+export function createFetchHandler(
+  config: MediaHostConfig
+): (request: Request) => Promise<Response> {
+  return async (request: Request): Promise<Response> => {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/healthz' && request.method === 'GET') {
+      return jsonResponse({ ok: true });
+    }
+
+    const relativePath = normalizeMediaPath(url.pathname);
+    if (relativePath === null) {
+      return jsonResponse({ error: 'Invalid path' }, 400);
+    }
+
+    if (request.method === 'PUT' || request.method === 'POST') {
+      return handleUpload(request, relativePath, config);
+    }
+
+    if (request.method === 'GET') {
+      return handleDownload(url, relativePath, config);
+    }
+
+    return jsonResponse({ error: 'Method Not Allowed' }, 405);
+  };
+}
+
+export function buildServer(config: MediaHostConfig): ReturnType<typeof Bun.serve> {
+  const handler = createFetchHandler(config);
+
+  return Bun.serve({
+    port: config.port,
+    hostname: config.host,
+    // Allow uploads up to the configured maximum (Bun defaults to 128 MiB).
+    maxRequestBodySize: config.maxUploadBytes,
+    fetch: handler,
+    error(error) {
+      console.error('[media_host] Server error', error);
+      return jsonResponse({ error: 'Internal Server Error' }, 500);
+    },
+  });
+}
+
+function main(): void {
+  const config = loadConfigFromEnv();
+  const server = buildServer(config);
+
+  console.log(
+    `[media_host] listening on http://${server.hostname}:${server.port} storing files under ${config.storageDir}`
+  );
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/src/media-host/server.ts
+++ b/src/media-host/server.ts
@@ -21,7 +21,7 @@ export interface MediaHostConfig {
 }
 
 function getDefaultStorageDir(): string {
-  return join(homedir(), '.cache', 'tim', 'media-host');
+  return join(homedir(), '.local', 'share', 'tim', 'media-host');
 }
 
 export function loadConfigFromEnv(): MediaHostConfig {

--- a/src/media-host/server.ts
+++ b/src/media-host/server.ts
@@ -99,6 +99,10 @@ export function normalizeMediaPath(pathname: string): string | null {
   return relativePath;
 }
 
+function encodeMediaPath(relativePath: string): string {
+  return relativePath.split('/').map(encodeURIComponent).join('/');
+}
+
 async function handleUpload(
   request: Request,
   relativePath: string,
@@ -135,7 +139,7 @@ async function handleUpload(
     {
       path: relativePath,
       size: body.byteLength,
-      url: `/${relativePath}?${SIGNATURE_PARAM}=${signature}`,
+      url: `/${encodeMediaPath(relativePath)}?${SIGNATURE_PARAM}=${signature}`,
     },
     201
   );


### PR DESCRIPTION
Introduces a standalone Bun server for hosting uploaded files with bearer-token-gated uploads and signature-verified downloads.

## Summary

Adds a new `media-host` service (`src/media-host/`) that provides:
- **Uploads** via `PUT`/`POST` with bearer token authentication
- **Downloads** via `GET` with path-bound HMAC-SHA256 signatures
- Path-traversal protection and configurable upload size limits
- Health check endpoint

## Key Changes

- **`src/media-host/server.ts`** — Main server implementation
  - `createFetchHandler()` — Request router supporting uploads, downloads, and health checks
  - `normalizeMediaPath()` — Canonicalizes request paths (decodes, strips slashes, rejects NUL bytes)
  - `handleUpload()` — Validates bearer token, enforces size limits, writes files, returns signed URL
  - `handleDownload()` — Verifies path signature before serving files
  - `loadConfigFromEnv()` — Reads configuration from environment variables with validation
  - `buildServer()` — Initializes Bun server with configured limits

- **`src/media-host/security.ts`** — Cryptographic utilities
  - `constantTimeEquals()` — Timing-safe string comparison
  - `hasValidBearerToken()` — Validates `Authorization: Bearer` header
  - `computePathSignature()` — HMAC-SHA256 signing of file paths
  - `isValidPathSignature()` — Constant-time signature verification

- **Test coverage** — Comprehensive test suites
  - `server.test.ts` — Integration tests for uploads, downloads, path validation, and error cases
  - `security.test.ts` — Unit tests for cryptographic functions and token validation

- **Documentation** — README section documenting configuration, usage examples, and API

- **Package.json** — Added `media-host` script entry point

## Implementation Details

- Uploads are validated against `MEDIA_HOST_MAX_UPLOAD_BYTES` (default 100 MiB) both via `Content-Length` header and actual body size
- Download URLs include a query parameter signature that is path-specific and cannot be forged without the signing secret
- Path traversal attempts (including percent-encoded separators like `%2f`) are rejected by `validatePath()` from the common fs utilities
- Files are stored under a configurable directory (default `~/.cache/tim/media-host`) with subdirectory structure preserved
- Content-type inference and cache headers are handled by Bun's `Response` constructor

https://claude.ai/code/session_01CBH1rWho3yYa5oEjs38i9p